### PR TITLE
Update new mpc service endpoint

### DIFF
--- a/src/components/AuthCallback/AuthCallback.tsx
+++ b/src/components/AuthCallback/AuthCallback.tsx
@@ -72,7 +72,7 @@ const onCreateAccount = async ({
     headers,
   };
 
-  return fetch(`${network.fastAuth.newMpcRecoveryUrl}/new_account`, options)
+  return fetch(`${network.fastAuth.mpcRecoveryUrl}/new_account`, options)
     .then(
       async (response) => {
         if (!response?.ok) {

--- a/src/lib/controller.ts
+++ b/src/lib/controller.ts
@@ -196,8 +196,7 @@ class FastAuthController {
     };
 
     // https://github.com/near/mpc-recovery#claim-oidc-id-token-ownership
-    // TODO: replace newMpcRecoveryUrl to mpcRecovery when all endpoint is implemented
-    return fetch(`${network.fastAuth.newMpcRecoveryUrl}/claim_oidc`, {
+    return fetch(`${network.fastAuth.mpcRecoveryUrl}/claim_oidc`, {
       method:  'POST',
       mode:    'cors' as const,
       body:    JSON.stringify(data),
@@ -231,8 +230,7 @@ class FastAuthController {
     };
 
     // https://github.com/near/mpc-recovery#user-credentials
-    // TODO: replace newMpcRecoveryUrl to mpcRecovery when all endpoint is implemented
-    return fetch(`${network.fastAuth.newMpcRecoveryUrl}/user_credentials`, {
+    return fetch(`${network.fastAuth.mpcRecoveryUrl}/user_credentials`, {
       method:  'POST',
       mode:    'cors' as const,
       body:    JSON.stringify(data),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,7 +10,7 @@ export const networks: Record<NetworkId, Network> = {
     relayerUrl:    process.env.RELAYER_URL,
     explorerUrl:   'https://explorer.near.org',
     fastAuth:      {
-      mpcRecoveryUrl:  'https://mpc-recovery-leader-mainnet-cg7nolnlpa-ue.a.run.app',
+      mpcRecoveryUrl:  'https://mpc-recovery-leader-mainnet-tmp-cg7nolnlpa-ue.a.run.app',
       authHelperUrl:   'https://api.kitwallet.app',
       accountIdSuffix: 'near',
       firebase:        {
@@ -33,9 +33,7 @@ export const networks: Record<NetworkId, Network> = {
     relayerUrl:    process.env.RELAYER_URL_TESTNET,
     explorerUrl:    'https://explorer.testnet.near.org',
     fastAuth:      {
-      mpcRecoveryUrl:    'https://mpc-recovery-leader-testnet-cg7nolnlpa-ue.a.run.app',
-      // TODO: replace newMpcRecoveryUrl to mpcRecovery when all endpoint is implemented
-      newMpcRecoveryUrl: 'https://mpc-recovery-leader-dev-7tk2cmmtcq-ue.a.run.app',
+      mpcRecoveryUrl:    'https://mpc-recovery-leader-dev-7tk2cmmtcq-ue.a.run.app',
       authHelperUrl:   'https://testnet-api.kitwallet.app',
       accountIdSuffix: 'testnet',
       firebase:        {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -19,7 +19,6 @@ type ProductionNetwork = {
   explorerUrl: string;
   fastAuth: {
     mpcRecoveryUrl: string;
-    newMpcRecoveryUrl?: string;
     authHelperUrl: string; // TODO refactor: review by fastauth team
     accountIdSuffix: string;
     firebase: {


### PR DESCRIPTION
This PR contains following changes:
1. Removing `newMpcRecoveryUrl` and unifying them into existing `mpcRecoveryUrl`
2. Updating a new mpc service endpoint

