### PR TITLE
Disable auto delete lak, decoupling FAK, LAK on firestore, improvements on Devices page

### DIFF
--- a/src/components/AddDevice/AddDevice.tsx
+++ b/src/components/AddDevice/AddDevice.tsx
@@ -182,7 +182,7 @@ function SignInPage() {
       const public_key =  decodeIfTruthy(searchParams.get('public_key'));
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
-      const gateway = getDomain(success_url) || contract_id;
+      const gateway = getDomain(success_url) || 'Unknown Gateway';
 
       const email = decodeIfTruthy(searchParams.get('email'));
       if (authenticated === true && isFirestoreReady) {

--- a/src/components/AddDevice/AddDevice.tsx
+++ b/src/components/AddDevice/AddDevice.tsx
@@ -182,6 +182,7 @@ function SignInPage() {
       const public_key =  decodeIfTruthy(searchParams.get('public_key'));
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
+      const gateway = decodeIfTruthy(searchParams.get('gateway'));
 
       const email = decodeIfTruthy(searchParams.get('email'));
       if (authenticated === true && isFirestoreReady) {
@@ -228,9 +229,12 @@ function SignInPage() {
             // @ts-ignore
             oidcToken: user.accessToken,
           });
+
+          // Since FAK is already added, we only add LAK
           return window.firestoreController.addDeviceCollection({
-            fakPublicKey: publicKeyFak,
+            fakPublicKey:  null,
             lakPublicKey: public_key,
+            gateway:      gateway || contract_id,
           })
             .then(() => {
               const parsedUrl = new URL(success_url || window.location.origin);

--- a/src/components/AddDevice/AddDevice.tsx
+++ b/src/components/AddDevice/AddDevice.tsx
@@ -182,7 +182,6 @@ function SignInPage() {
       const public_key =  decodeIfTruthy(searchParams.get('public_key'));
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
-      const gateway = getDomain(success_url) || 'Unknown Gateway';
 
       const email = decodeIfTruthy(searchParams.get('email'));
       if (authenticated === true && isFirestoreReady) {
@@ -234,7 +233,7 @@ function SignInPage() {
           return window.firestoreController.addDeviceCollection({
             fakPublicKey:  null,
             lakPublicKey: public_key,
-            gateway,
+            gateway: success_url,
           })
             .then(() => {
               const parsedUrl = new URL(success_url || window.location.origin);

--- a/src/components/AddDevice/AddDevice.tsx
+++ b/src/components/AddDevice/AddDevice.tsx
@@ -12,7 +12,7 @@ import { openToast } from '../../lib/Toast';
 import { useAuthState } from '../../lib/useAuthState';
 import { decodeIfTruthy, inIframe } from '../../utils';
 import { basePath } from '../../utils/config';
-import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
+import { checkFirestoreReady, firebaseAuth, getDomain } from '../../utils/firebase';
 import { isValidEmail } from '../../utils/form-validation';
 
 const StyledContainer = styled.div`
@@ -182,7 +182,7 @@ function SignInPage() {
       const public_key =  decodeIfTruthy(searchParams.get('public_key'));
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
-      const gateway = decodeIfTruthy(searchParams.get('gateway'));
+      const gateway = getDomain(success_url) || contract_id;
 
       const email = decodeIfTruthy(searchParams.get('email'));
       if (authenticated === true && isFirestoreReady) {
@@ -234,7 +234,7 @@ function SignInPage() {
           return window.firestoreController.addDeviceCollection({
             fakPublicKey:  null,
             lakPublicKey: public_key,
-            gateway:      gateway || contract_id,
+            gateway,
           })
             .then(() => {
               const parsedUrl = new URL(success_url || window.location.origin);

--- a/src/components/AuthCallback/AuthCallback.tsx
+++ b/src/components/AuthCallback/AuthCallback.tsx
@@ -222,7 +222,6 @@ function AuthCallbackPage() {
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
       const privateKey = window.localStorage.getItem(`temp_fastauthflow_${publicKeyFak}`);
-      const gateway  = getDomain(success_url) || 'Unknown Gateway';
 
       while (!email) {
         // TODO refactor: review
@@ -275,7 +274,7 @@ function AuthCallbackPage() {
                 email,
                 navigate,
                 searchParams,
-                gateway,
+                gateway:      success_url,
               });
             } catch (e) {
               console.log('error:', e);

--- a/src/components/AuthCallback/AuthCallback.tsx
+++ b/src/components/AuthCallback/AuthCallback.tsx
@@ -11,7 +11,7 @@ import FirestoreController from '../../lib/firestoreController';
 import { openToast } from '../../lib/Toast';
 import { decodeIfTruthy, inIframe } from '../../utils';
 import { network, networkId } from '../../utils/config';
-import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
+import { checkFirestoreReady, firebaseAuth, getDomain } from '../../utils/firebase';
 import {
   CLAIM, getAddKeyAction, getUserCredentialsFrpSignature, getDeleteKeysAction, getAddLAKAction
 } from '../../utils/mpc-service';
@@ -222,7 +222,7 @@ function AuthCallbackPage() {
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
       const privateKey = window.localStorage.getItem(`temp_fastauthflow_${publicKeyFak}`);
-      const gateway  = decodeIfTruthy(searchParams.get('gateway')) || contract_id;
+      const gateway  = getDomain(success_url) || contract_id;
 
       while (!email) {
         // TODO refactor: review

--- a/src/components/AuthCallback/AuthCallback.tsx
+++ b/src/components/AuthCallback/AuthCallback.tsx
@@ -222,7 +222,7 @@ function AuthCallbackPage() {
       const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
       const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
       const privateKey = window.localStorage.getItem(`temp_fastauthflow_${publicKeyFak}`);
-      const gateway  = getDomain(success_url) || contract_id;
+      const gateway  = getDomain(success_url) || 'Unknown Gateway';
 
       while (!email) {
         // TODO refactor: review

--- a/src/components/Devices/Devices.tsx
+++ b/src/components/Devices/Devices.tsx
@@ -9,6 +9,7 @@ import { useAuthState } from '../../lib/useAuthState';
 import { decodeIfTruthy } from '../../utils';
 import { networkId } from '../../utils/config';
 import { onSignIn } from '../AuthCallback/AuthCallback';
+import { getDomain } from '../../utils/firebase';
 
 const Title = styled.h1`
   padding-bottom: 20px;
@@ -111,7 +112,7 @@ function Devices() {
         const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
         const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
         const success_url = decodeIfTruthy(searchParams.get('success_url'));
-        const gateway = decodeIfTruthy(searchParams.get('gateway')) || contract_id;
+        const gateway = getDomain(success_url) || contract_id;
         const oidcToken = await controller.getUserOidcToken();
 
         await onSignIn({

--- a/src/components/Devices/Devices.tsx
+++ b/src/components/Devices/Devices.tsx
@@ -112,7 +112,6 @@ function Devices() {
         const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
         const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
         const success_url = decodeIfTruthy(searchParams.get('success_url'));
-        const gateway = getDomain(success_url) || 'Unknown Gateway';
         const oidcToken = await controller.getUserOidcToken();
 
         await onSignIn({
@@ -127,7 +126,7 @@ function Devices() {
           searchParams,
           navigate,
           onlyAddLak:       publicKeyFak === 'null',
-          gateway,
+          gateway:          success_url,
         });
         setIsAddingKey(false);
       }).catch((err) => {

--- a/src/components/Devices/Devices.tsx
+++ b/src/components/Devices/Devices.tsx
@@ -112,7 +112,7 @@ function Devices() {
         const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
         const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
         const success_url = decodeIfTruthy(searchParams.get('success_url'));
-        const gateway = getDomain(success_url) || contract_id;
+        const gateway = getDomain(success_url) || 'Unknown Gateway';
         const oidcToken = await controller.getUserOidcToken();
 
         await onSignIn({

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -15,3 +15,13 @@ export const checkFirestoreReady = async () => firebaseAuth.authStateReady()
     }
     return false;
   });
+
+export const getDomain = (url) => {
+  let urlObj;
+  try {
+    urlObj = new URL(url);
+  } catch {
+    return false;
+  }
+  return urlObj.hostname.replace('www.', '');
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -53,6 +53,9 @@ export type Device = {
   browser: string;
   publicKeys: string[];
   uid: string;
+  gateway: string;
+  dateTime: Date;
+  keyType: string;
 };
 
 export type DeleteDevice = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -53,7 +53,7 @@ export type Device = {
   browser: string;
   publicKeys: string[];
   uid: string;
-  gateway: string;
+  gateway: string | null;
   dateTime: Date;
   keyType: string;
 };


### PR DESCRIPTION
This PR contains following changes:
1. Undo auto delete LAK logic that existed before
2. New update on handling FAK and LAK on firestore. Now each collection represents only one key. Added more details on each collection to make the Devices page for informative
3. UI/UX improvements on Devices page:

<img width="1001" alt="Greenshot 2023-10-04 16 48 03" src="https://github.com/near/fast-auth-signer/assets/6027014/3016bba2-77cb-4088-9bfe-413e4cb9cbab">
