### PR TITLE
feat: implementation to support create and signin on non-webauthN sup…

### DIFF
--- a/src/components/AddDevice/AddDevice.tsx
+++ b/src/components/AddDevice/AddDevice.tsx
@@ -192,7 +192,15 @@ function SignInPage() {
           window.location.replace(success_url || window.location.origin);
           return;
         }
-        const publicKeyFak = await window.fastAuthController.getPublicKey();
+
+        let publicKeyFak;
+        if (await isPassKeyAvailable()) {
+          publicKeyFak = await window.fastAuthController.getPublicKey();
+        } else {
+          const keypair = await window.fastAuthController.getKey('oidc_keypair');
+          publicKeyFak = keypair.getPublicKey().toString();
+        }
+
         const existingDevice = await window.firestoreController.getDeviceCollection(publicKeyFak);
         const existingDeviceLakKey = existingDevice?.publicKeys?.filter((key) => key !== publicKeyFak)[0];
         // if given lak key is already attached to webAuthN public key, no need to add it again

--- a/src/components/AuthCallback/AuthCallback.tsx
+++ b/src/components/AuthCallback/AuthCallback.tsx
@@ -115,8 +115,9 @@ const onCreateAccount = async ({
 };
 
 export const onSignIn = async ({
+  oidcKeypair,
   accessToken,
-  publicKeyFak,
+  publicKeyFak: publicKeyFakRaw,
   public_key_lak,
   contract_id,
   methodNames,
@@ -135,6 +136,7 @@ export const onSignIn = async ({
       throw new Error('Unable to retrieve account Id');
     });
 
+  const publicKeyFak = publicKeyFakRaw || oidcKeypair.getPublicKey().toString();
   // TODO: If we want to remove old LAK automatically, use below code and add deleteKeyActions to signAndSendActionsWithRecoveryKey
   // const existingDevice = await window.firestoreController.getDeviceCollection(publicKeyFak);
   // // delete old lak key attached to webAuthN public Key
@@ -181,7 +183,6 @@ export const onSignIn = async ({
         });
 
         setStatusMessage('Account recovered successfully!');
-
         if (publicKeyFak) {
           window.localStorage.setItem('webauthn_username', email);
         }

--- a/src/components/Devices/Devices.tsx
+++ b/src/components/Devices/Devices.tsx
@@ -9,7 +9,7 @@ import { useAuthState } from '../../lib/useAuthState';
 import { decodeIfTruthy } from '../../utils';
 import { networkId } from '../../utils/config';
 import { onSignIn } from '../AuthCallback/AuthCallback';
-import { getDomain } from '../../utils/firebase';
+import { isPassKeyAvailable } from '@near-js/biometric-ed25519';
 
 const Title = styled.h1`
   padding-bottom: 20px;
@@ -71,12 +71,12 @@ function Devices() {
       const privateKey = window.localStorage.getItem(`temp_fastauthflow_${publicKeyFak}`);
       if (privateKey) {
         const accountId = await controller.getAccountIdFromOidcToken();
-
-        // claim the oidc token
-        (window as any).fastAuthController = new FastAuthController({
-          accountId,
-          networkId
-        });
+        if (!window.fastAuthController) {
+          (window as any).fastAuthController = new FastAuthController({
+            accountId,
+            networkId
+          });
+        }
         const keypair = new KeyPairEd25519(privateKey.split(':')[1]);
         await window.fastAuthController.setKey(keypair);
       }
@@ -85,7 +85,7 @@ function Devices() {
       setIsLoaded(false);
       setCollections(deviceCollections);
     };
-    if (authenticated === true) {
+    if (authenticated !== 'loading') {
       getCollection();
     }
   }, [authenticated]);
@@ -101,6 +101,18 @@ function Devices() {
         };
       });
 
+    const getPublicKeyFak = async (existingPublicKeyFak) => {
+      if (existingPublicKeyFak !== 'null') return existingPublicKeyFak;
+      if (await isPassKeyAvailable()) {
+        const publicKey = await window.fastAuthController.getPublicKey();
+        return publicKey;
+      }
+      // Non WebAuthN supported browser
+      const keypair = await window.fastAuthController.getKey('oidc_keypair')
+        || await window.fastAuthController.getKey(window.fastAuthController.getAccountId());
+      return keypair.getPublicKey().toString();
+    };
+
     return controller.deleteDeviceCollections(list)
       .then(async () => {
         setisDeleted(false);
@@ -108,15 +120,17 @@ function Devices() {
         setDeleteCollections([]);
         setIsAddingKey(true);
 
-        const email = decodeIfTruthy(searchParams.get('email'));
+        const email = decodeIfTruthy(searchParams.get('email')) || window.localStorage.getItem('emailForSignIn');
         const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
         const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
         const success_url = decodeIfTruthy(searchParams.get('success_url'));
         const oidcToken = await controller.getUserOidcToken();
+        const oidcKeypair = await window.fastAuthController.getKey('oidc_keypair');
 
         await onSignIn({
+          oidcKeypair,
           accessToken:      oidcToken,
-          publicKeyFak:     publicKeyFak !== 'null' ? publicKeyFak : await window.fastAuthController.getPublicKey(),
+          publicKeyFak:     await getPublicKeyFak(publicKeyFak),
           public_key_lak:   public_key_lak !== 'null' ? public_key_lak : decodeIfTruthy(searchParams.get('public_key')),
           contract_id,
           methodNames,

--- a/src/lib/firestoreController.ts
+++ b/src/lib/firestoreController.ts
@@ -121,10 +121,14 @@ class FirestoreController {
     // if account id is not set, retrieve and reinitialize fastAuthController
     if (!window.fastAuthController.getAccountId()) {
       const accountId = await this.getAccountIdFromOidcToken();
-      (window as any).fastAuthController = new FastAuthController({
-        accountId,
-        networkId
-      });
+      if (window.fastAuthController) {
+        window.fastAuthController.setAccountId(accountId);
+      } else {
+        (window as any).fastAuthController = new FastAuthController({
+          accountId,
+          networkId
+        });
+      }
     }
 
     const accessKeysWithoutRecoveryKey = await window.fastAuthController


### PR DESCRIPTION
This PR contains implementation to support non web-authN supported browser.
(Mainly Firefox browsers for now)

I have tested following:
create account on Firefox, sign out -> sign back in same browser, delete devices and sign in
create account on Chrome, sign out -> sign back in same browser, delete devices and sign in
create account on Firefox, sign out -> sign back in Chrome browser
