### PR TITLE
Supporting non webauthn browser with FAK action

### DIFF
--- a/packages/near-fast-auth-signer/src/App.tsx
+++ b/packages/near-fast-auth-signer/src/App.tsx
@@ -17,11 +17,11 @@ import FastAuthController from './lib/controller';
 import './styles/theme.css';
 import './styles/globals.css';
 import GlobalStyle from './styles/index';
-import { basePath } from './utils/config';
+import { basePath, networkId } from './utils/config';
 
 (window as any).fastAuthController = new FastAuthController({
   accountId: 'harisvalj.testnet',
-  networkId: 'testnet'
+  networkId
 });
 
 const faLog = debug('fastAuth');

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -17,7 +17,12 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
   if (!res.ok) {
     throw new Error(`HTTP error! status: ${res.status}`);
   }
-  return res.json();
+
+  const accountIds = await res.json();
+  if (accountIds.length === 0) {
+    throw new Error('Unable to retrieve account id');
+  }
+  return accountIds;
 };
 
 type LimitedAccessKey = {

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -2,7 +2,9 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { captureException } from '@sentry/react';
 import BN from 'bn.js';
 import { sendSignInLinkToEmail } from 'firebase/auth';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useState
+} from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -259,7 +261,7 @@ function SignInPage() {
     if (requireVerifyEmail) return;
 
     handleAuthCallback();
-  }, [addDevice, authenticated, navigate, searchParams]);
+  }, [addDevice, authenticated, navigate, searchParams, requireVerifyEmail]);
 
   if (authenticated === true && !requireVerifyEmail) {
     return renderRedirectButton ? (

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -3,7 +3,7 @@ import { captureException } from '@sentry/react';
 import BN from 'bn.js';
 import { sendSignInLinkToEmail } from 'firebase/auth';
 import React, {
-  useCallback, useEffect, useMemo, useState
+  useCallback, useEffect, useState
 } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -165,9 +165,9 @@ function SignInPage() {
       const isPasskeySupported = await isPassKeyAvailable();
       const user = firebaseAuth.currentUser;
       const firebaseAuthInvalid = authenticated === true && !isPasskeySupported && user?.email !== email;
-      const shouldUseCurrentUser = (isPasskeySupported
-        ? authenticated === true
-        : !firebaseAuthInvalid) && isFirestoreReady;
+      const shouldUseCurrentUser = authenticated === true
+        && (isPasskeySupported || !firebaseAuthInvalid)
+        && isFirestoreReady;
 
       if (shouldUseCurrentUser) {
         if (!public_key || !contract_id) {

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -165,7 +165,11 @@ function SignInPage() {
       const isPasskeySupported = await isPassKeyAvailable();
       const user = firebaseAuth.currentUser;
       const firebaseAuthInvalid = authenticated === true && !isPasskeySupported && user?.email !== email;
-      if (authenticated === true && isFirestoreReady && !firebaseAuthInvalid) {
+      const shouldUseCurrentUser = (isPasskeySupported
+        ? authenticated === true
+        : !firebaseAuthInvalid) && isFirestoreReady;
+
+      if (shouldUseCurrentUser) {
         if (!public_key || !contract_id) {
           window.location.replace(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
           return;

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { isPassKeyAvailable } from '@near-js/biometric-ed25519';
 import { captureException } from '@sentry/react';
 import BN from 'bn.js';
 import { sendSignInLinkToEmail } from 'firebase/auth';

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -175,12 +175,12 @@ function SignInPage() {
 
         // if given lak key is already attached to webAuthN public key, no need to add it again
         const noNeedToAddKey = existingDeviceLakKey === public_key;
-        if (noNeedToAddKey) {
-          const parsedUrl = new URL(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
-          parsedUrl.searchParams.set('account_id', window.fastAuthController.getAccountId());
-          parsedUrl.searchParams.set('public_key', public_key);
-          parsedUrl.searchParams.set('all_keys', [public_key, publicKeyFak, recoveryPK].join(','));
+        const parsedUrl = new URL(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
+        parsedUrl.searchParams.set('account_id', (window as any).fastAuthController.getAccountId());
+        parsedUrl.searchParams.set('public_key', public_key);
+        parsedUrl.searchParams.set('all_keys', [public_key, publicKeyFak, recoveryPK].join(','));
 
+        if (noNeedToAddKey) {
           if (inIframe()) {
             setRenderRedirectButton(parsedUrl.href);
           } else {
@@ -215,10 +215,6 @@ function SignInPage() {
             gateway:      success_url,
           })
             .then(() => {
-              const parsedUrl = new URL(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
-              parsedUrl.searchParams.set('account_id', window.fastAuthController.getAccountId());
-              parsedUrl.searchParams.set('public_key', public_key);
-              parsedUrl.searchParams.set('all_keys', [public_key, publicKeyFak, recoveryPK].join(','));
               window.parent.postMessage({
                 type:   'method',
                 method: 'query',

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -73,11 +73,12 @@ const onCreateAccount = async ({
   }
 
   setStatusMessage('Redirecting to app...');
-
+  
+  const recoveryPK = await window.fastAuthController.getUserCredential(accessToken);
   const parsedUrl = new URL(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
   parsedUrl.searchParams.set('account_id', res.near_account_id);
   parsedUrl.searchParams.set('public_key', public_key_lak);
-  parsedUrl.searchParams.set('all_keys', (publicKeyFak ? [public_key_lak, publicKeyFak] : [public_key_lak]).join(','));
+  parsedUrl.searchParams.set('all_keys', (publicKeyFak ? [public_key_lak, publicKeyFak, recoveryPK] : [public_key_lak, recoveryPK]).join(','));
 
   window.location.replace(parsedUrl.href);
 };
@@ -163,7 +164,7 @@ export const onSignIn = async ({
         const parsedUrl = new URL(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
         parsedUrl.searchParams.set('account_id', accountIds[0]);
         parsedUrl.searchParams.set('public_key', public_key_lak);
-        parsedUrl.searchParams.set('all_keys', (publicKeyFak ? [public_key_lak, publicKeyFak] : [public_key_lak]).join(','));
+        parsedUrl.searchParams.set('all_keys', (publicKeyFak ? [public_key_lak, publicKeyFak, recoveryPK] : [public_key_lak, recoveryPK]).join(','));
 
         if (inIframe()) {
           window.open(parsedUrl.href, '_parent');
@@ -223,6 +224,10 @@ function AuthCallbackPage() {
             const keyPair = await createKey(email);
             publicKeyFak = keyPair.getPublicKey().toString();
             await window.fastAuthController.setKey(keyPair);
+          }
+
+          if (!window.fastAuthController.getAccountId()) {
+            await window.fastAuthController.setAccountId(accountId);
           }
 
           await window.fastAuthController.claimOidcToken(accessToken);

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -73,7 +73,7 @@ const onCreateAccount = async ({
   }
 
   setStatusMessage('Redirecting to app...');
-  
+
   const recoveryPK = await window.fastAuthController.getUserCredential(accessToken);
   const parsedUrl = new URL(success_url || window.location.origin + (basePath ? `/${basePath}` : ''));
   parsedUrl.searchParams.set('account_id', res.near_account_id);

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { createNEARAccount } from '../../api';
 import FastAuthController from '../../lib/controller';
 import FirestoreController from '../../lib/firestoreController';
-import { decodeIfTruthy, inIframe, redirectWithError } from '../../utils';
+import { decodeIfTruthy, inIframe } from '../../utils';
 import { basePath, network, networkId } from '../../utils/config';
 import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
 import {

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { createNEARAccount } from '../../api';
 import FastAuthController from '../../lib/controller';
 import FirestoreController from '../../lib/firestoreController';
-import { decodeIfTruthy, inIframe } from '../../utils';
+import { decodeIfTruthy, inIframe, redirectWithError } from '../../utils';
 import { basePath, network, networkId } from '../../utils/config';
 import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
 import {

--- a/packages/near-fast-auth-signer/src/components/AuthIndicator/AuthIndicator.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthIndicator/AuthIndicator.tsx
@@ -12,7 +12,7 @@ function AuthIndicator() {
     if (authenticated !== 'loading' && authenticated === false) {
       navigate('/login');
     }
-  }, [authenticated]);
+  }, [authenticated, navigate]);
 
   return (
     <AuthIndicatorButton data-test-id="auth-indicator-button" $buttonType="secondary" $isSignedIn={authenticated && authenticated !== 'loading'}>

--- a/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
+++ b/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
@@ -69,7 +69,7 @@ function Devices() {
       setCollections(deviceCollections);
     };
 
-    const getKeypairOrLogout = () => window.fastAuthController.getKey(`oidc_keypair_${controller.getUserOidcToken()}`).then((keypair) => {
+    const getKeypairOrLogout = () => window.fastAuthController.findInKeyStores(`oidc_keypair_${controller.getUserOidcToken()}`).then((keypair) => {
       if (keypair) {
         getCollection();
       } else {
@@ -94,7 +94,6 @@ function Devices() {
   }, [controller]);
 
   const redirectToSignin = () => {
-    window.localStorage.setItem('requireVerifyEmail', 'true');
     if (inIframe()) {
       window.open(`${window.location.origin}${basePath ? `/${basePath}` : ''}/login?${searchParams.toString()}`, '_parent');
     } else {

--- a/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
+++ b/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
@@ -94,6 +94,7 @@ function Devices() {
   }, [controller]);
 
   const redirectToSignin = () => {
+    window.localStorage.setItem('requireVerifyEmail', 'true');
     if (inIframe()) {
       window.open(`${window.location.origin}${basePath ? `/${basePath}` : ''}/login?${searchParams.toString()}`, '_parent');
     } else {

--- a/packages/near-fast-auth-signer/src/components/RpcRoute/RpcRoute.tsx
+++ b/packages/near-fast-auth-signer/src/components/RpcRoute/RpcRoute.tsx
@@ -1,14 +1,31 @@
 import { useEffect } from 'react';
 
+import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
+
 function RpcRoute() {
   useEffect(() => {
-    const listener = (e: MessageEvent) => {
+    const listener = async (e: MessageEvent) => {
       if (e.data.type === 'method' && e.data.params) {
         // eslint-disable-next-line default-case
         switch (e.data.params.request_type) {
           case 'get_pre_biometric_auth_account':
             try {
-              const username = window.localStorage.getItem('webauthn_username');
+              let username = window.localStorage.getItem('webauthn_username');
+              if (!username) {
+                username = await checkFirestoreReady().then(async (isReady) => {
+                  if (isReady) {
+                    const oidcToken = await firebaseAuth.currentUser.getIdToken();
+                    if (
+                      window.fastAuthController.getLocalStoreKey(
+                        `oidc_keypair_${oidcToken}`
+                      )
+                    ) {
+                      return firebaseAuth.currentUser.email;
+                    }
+                    return null;
+                  }
+                });
+              }
               window.parent.postMessage({
                 type:   'response',
                 id:     e.data.id,

--- a/packages/near-fast-auth-signer/src/components/RpcRoute/RpcRoute.tsx
+++ b/packages/near-fast-auth-signer/src/components/RpcRoute/RpcRoute.tsx
@@ -24,6 +24,7 @@ function RpcRoute() {
                     }
                     return null;
                   }
+                  return null;
                 });
               }
               window.parent.postMessage({

--- a/packages/near-fast-auth-signer/src/components/Sign/Sign.tsx
+++ b/packages/near-fast-auth-signer/src/components/Sign/Sign.tsx
@@ -139,6 +139,7 @@ function Sign() {
       .catch(() => {
         console.warn('Coin Gecko Error');
       });
+  // eslint-disable-next-line
   }, []);
 
   const fiatValueUsd = fiatValuesStore((state) => state.fiatValueUsd);

--- a/packages/near-fast-auth-signer/src/components/Sign/Sign.tsx
+++ b/packages/near-fast-auth-signer/src/components/Sign/Sign.tsx
@@ -166,7 +166,7 @@ function Sign() {
   };
 
   const onConfirm = async () => {
-    if (authenticated) {
+    if (authenticated === true) {
       const signedTransactions = [];
       const success_url = searchParams.get('success_url');
       for (let i = 0; i < transactionDetails.transactions.length; i += 1) {

--- a/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
+++ b/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
@@ -119,10 +119,6 @@ function VerifyEmailPage() {
     }
   };
 
-  useEffect(() => {
-    window.localStorage.removeItem('requireVerifyEmail');
-  }, []);
-
   return (
     <StyledContainer>
       <FormContainer onSubmit={handleResendEmail}>

--- a/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
+++ b/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
@@ -1,5 +1,5 @@
 import { sendSignInLinkToEmail } from 'firebase/auth';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -118,6 +118,10 @@ function VerifyEmailPage() {
       });
     }
   };
+
+  useEffect(() => {
+    window.localStorage.removeItem('requireVerifyEmail');
+  }, []);
 
   return (
     <StyledContainer>

--- a/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
+++ b/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
@@ -1,5 +1,5 @@
 import { sendSignInLinkToEmail } from 'firebase/auth';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -13,7 +13,6 @@ import { baseEncode, serialize } from 'borsh';
 import { sha256 } from 'js-sha256';
 import { keyStores } from 'near-api-js';
 
-import FirestoreController from './firestoreController';
 import networkParams from './networkParams';
 import { network } from '../utils/config';
 import { firebaseAuth } from '../utils/firebase';
@@ -180,7 +179,7 @@ class FastAuthController {
         captureException(err);
         throw new Error('Unable to sign delegate action');
       });
-    };
+    }
   }
 
   async signAndSendDelegateAction({ receiverId, actions }) {

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -11,9 +11,12 @@ import { captureException } from '@sentry/react';
 import BN from 'bn.js';
 import { baseEncode, serialize } from 'borsh';
 import { sha256 } from 'js-sha256';
+import { keyStores } from 'near-api-js';
 
+import FirestoreController from './firestoreController';
 import networkParams from './networkParams';
 import { network } from '../utils/config';
+import { firebaseAuth } from '../utils/firebase';
 import { CLAIM, getSignRequestFrpSignature, getUserCredentialsFrpSignature } from '../utils/mpc-service';
 
 const { addKey, functionCallAccessKey } = actionCreators;
@@ -24,6 +27,8 @@ class FastAuthController {
 
   private keyStore: InMemoryKeyStore;
 
+  private localStore: keyStores.BrowserLocalStorageKeyStore;
+
   private connection: Connection;
 
   constructor({ accountId, networkId }) {
@@ -33,6 +38,7 @@ class FastAuthController {
     }
 
     this.keyStore = new InMemoryKeyStore();
+    this.localStore = new keyStores.BrowserLocalStorageKeyStore();
 
     this.connection = Connection.fromConfig({
       networkId,
@@ -101,6 +107,10 @@ class FastAuthController {
     return !!(await this.getKey());
   }
 
+  async getLocalStoreKey(accountId) {
+    return this.localStore.getKey(this.networkId, accountId);
+  }
+
   assertValidSigner(signerId) {
     if (signerId && signerId !== this.accountId) {
       throw new Error(`Cannot sign transactions for ${signerId} while signed in as ${this.accountId}`);
@@ -145,8 +155,41 @@ class FastAuthController {
   }
 
   async signDelegateAction({ receiverId, actions, signerId }) {
-    this.assertValidSigner(signerId);
+    const isSigned = await this.isSignedIn();
+    if (this.accountId !== signerId) {
+      this.setAccountId(signerId);
+      this.localStore = new keyStores.BrowserLocalStorageKeyStore();
+    }
+    if (!isSigned) {
+      // use indexDB token to get key from localStorage
+      if (!window.firestoreController) {
+        window.firestoreController = new FirestoreController();
+      }
+      // @ts-ignore
+      const oidcToken =  firebaseAuth.currentUser.accessToken;
+      const recoveryPK = await this.getUserCredential(oidcToken);
+      // fix PK
+      const accountIds = await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${recoveryPK}/accounts`)
+        .then((res) => res.json())
+        .catch((err) => {
+          console.log(err);
+          captureException(err);
+          throw new Error('Unable to retrieve account Id');
+        });
+      // make sure to handle failure, (eg token expired) if fail, redirect to failure_url
+      return this.createSignedDelegateWithRecoveryKey({
+        oidcToken,
+        accountId: accountIds[0],
+        actions,
+        recoveryPK,
+      }).catch((err) => {
+        console.log(err);
+        captureException(err);
+        throw new Error('Unable to sign delegate action');
+      });
+    }
 
+    this.assertValidSigner(signerId);
     const account = new Account(this.connection, this.accountId);
     return account.signedDelegate({
       actions,
@@ -199,6 +242,7 @@ class FastAuthController {
     if (!keypair) {
       keypair = KeyPair.fromRandom('ED25519');
       await this.keyStore.setKey(this.networkId, `oidc_keypair_${oidcToken}`, keypair);
+      await this.localStore.setKey(this.networkId, `oidc_keypair_${oidcToken}`, keypair);
     }
     const signature = getUserCredentialsFrpSignature({
       salt:            CLAIM_SALT,
@@ -232,8 +276,14 @@ class FastAuthController {
   }
 
   async getUserCredential(oidcToken) {
+    // @ts-ignore
     const GET_USER_SALT = CLAIM + 2;
-    const keypair = await this.getKey(`oidc_keypair_${oidcToken}`);
+    const keypair = await this.getKey(`oidc_keypair_${oidcToken}`) || await this.getLocalStoreKey(`oidc_keypair_${oidcToken}`);
+
+    if (!keypair) {
+      throw new Error('Unable to get oidc keypair');
+    }
+
     const signature = getUserCredentialsFrpSignature({
       salt:            GET_USER_SALT,
       oidcToken,
@@ -269,7 +319,7 @@ class FastAuthController {
     return this.connection.provider.block({ finality: 'final' });
   }
 
-  async signAndSendActionsWithRecoveryKey({
+  async createSignedDelegateWithRecoveryKey({
     oidcToken,
     accountId,
     recoveryPK,
@@ -277,7 +327,8 @@ class FastAuthController {
   }) {
     const GET_SIGNATURE_SALT = CLAIM + 3;
     const GET_USER_SALT = CLAIM + 2;
-    const localKey = await this.getKey(`oidc_keypair_${oidcToken}`);
+    const localKey = await this.getKey(`oidc_keypair_${oidcToken}`) || await this.getLocalStoreKey(`oidc_keypair_${oidcToken}`);
+
     const { header } = await this.getBlock();
     const delegateAction = buildDelegateAction({
       actions,
@@ -326,20 +377,38 @@ class FastAuthController {
         keyType: KeyType.ED25519,
         data:    Buffer.from(signature, 'hex'),
       });
-      const signedDelegate = new SignedDelegate({
+      return new SignedDelegate({
         delegateAction,
         signature: signatureObj,
       });
-      const encodedSignedDelegate = encodeSignedDelegate(signedDelegate);
-      return fetch(network.relayerUrl, {
-        method:  'POST',
-        mode:    'cors',
-        body:    JSON.stringify(Array.from(encodedSignedDelegate)),
-        headers: new Headers({ 'Content-Type': 'application/json' }),
-      }).catch((err) => {
-        console.log('Unable to sign and send action with recovery key', err);
-        captureException(err);
-      });
+    });
+  }
+
+  async signAndSendActionsWithRecoveryKey({
+    oidcToken,
+    accountId,
+    recoveryPK,
+    actions,
+  }) {
+    const signedDelegate = await this.createSignedDelegateWithRecoveryKey({
+      oidcToken,
+      accountId,
+      recoveryPK,
+      actions,
+    }).catch((err) => {
+      console.log(err);
+      captureException(err);
+      throw new Error('Unable to sign delegate action');
+    });
+    const encodedSignedDelegate = encodeSignedDelegate(signedDelegate);
+    return fetch(network.relayerUrl, {
+      method:  'POST',
+      mode:    'cors',
+      body:    JSON.stringify(Array.from(encodedSignedDelegate)),
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+    }).catch((err) => {
+      console.log('Unable to sign and send action with recovery key', err);
+      captureException(err);
     });
   }
 }

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -155,10 +155,11 @@ class FastAuthController {
 
   async signDelegateAction({ receiverId, actions, signerId }) {
     this.assertValidSigner(signerId);
+    let signedDelegate;
     try {
       // webAuthN supported browser
       const account = new Account(this.connection, this.accountId);
-      return account.signedDelegate({
+      signedDelegate = await account.signedDelegate({
         actions,
         blockHeightTtl: 60,
         receiverId,
@@ -169,7 +170,7 @@ class FastAuthController {
       const oidcToken = await firebaseAuth.currentUser.getIdToken();
       const recoveryPK = await this.getUserCredential(oidcToken);
       // make sure to handle failure, (eg token expired) if fail, redirect to failure_url
-      return this.createSignedDelegateWithRecoveryKey({
+      signedDelegate = await this.createSignedDelegateWithRecoveryKey({
         oidcToken,
         accountId: this.accountId,
         actions,
@@ -180,6 +181,7 @@ class FastAuthController {
         throw new Error('Unable to sign delegate action');
       });
     }
+    return signedDelegate;
   }
 
   async signAndSendDelegateAction({ receiverId, actions }) {

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -111,6 +111,11 @@ class FastAuthController {
     return this.localStore.getKey(this.networkId, accountId);
   }
 
+  async findInKeyStores(key) {
+    const keypair = await this.getKey(key) || await this.getLocalStoreKey(key);
+    return keypair;
+  }
+
   assertValidSigner(signerId) {
     if (signerId && signerId !== this.accountId) {
       throw new Error(`Cannot sign transactions for ${signerId} while signed in as ${this.accountId}`);

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -14,10 +14,10 @@ import { sha256 } from 'js-sha256';
 import { keyStores } from 'near-api-js';
 
 import networkParams from './networkParams';
+import { deleteOidcKeyPairOnLocalStorage } from '../utils';
 import { network } from '../utils/config';
 import { firebaseAuth } from '../utils/firebase';
 import { CLAIM, getSignRequestFrpSignature, getUserCredentialsFrpSignature } from '../utils/mpc-service';
-import { deleteOidcKeyPairOnLocalStorage } from '../utils';
 
 const { addKey, functionCallAccessKey } = actionCreators;
 class FastAuthController {

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -17,6 +17,7 @@ import networkParams from './networkParams';
 import { network } from '../utils/config';
 import { firebaseAuth } from '../utils/firebase';
 import { CLAIM, getSignRequestFrpSignature, getUserCredentialsFrpSignature } from '../utils/mpc-service';
+import { deleteOidcKeyPairOnLocalStorage } from '../utils';
 
 const { addKey, functionCallAccessKey } = actionCreators;
 class FastAuthController {
@@ -228,6 +229,8 @@ class FastAuthController {
     if (!keypair) {
       keypair = KeyPair.fromRandom('ED25519');
       await this.keyStore.setKey(this.networkId, `oidc_keypair_${oidcToken}`, keypair);
+      // Delete old oidc keypair
+      deleteOidcKeyPairOnLocalStorage();
       await this.localStore.setKey(this.networkId, `oidc_keypair_${oidcToken}`, keypair);
     }
     const signature = getUserCredentialsFrpSignature({

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -166,7 +166,7 @@ class FastAuthController {
     } catch {
       // fallback, non webAuthN supported browser
       // @ts-ignore
-      const oidcToken =  firebaseAuth.currentUser.accessToken;
+      const oidcToken = await firebaseAuth.currentUser.getIdToken();
       const recoveryPK = await this.getUserCredential(oidcToken);
       // make sure to handle failure, (eg token expired) if fail, redirect to failure_url
       return this.createSignedDelegateWithRecoveryKey({

--- a/packages/near-fast-auth-signer/src/lib/firestoreController.ts
+++ b/packages/near-fast-auth-signer/src/lib/firestoreController.ts
@@ -101,7 +101,10 @@ class FirestoreController {
       });
     });
 
-    await (window as any).fastAuthController.claimOidcToken(this.oidcToken);
+    const existingKeyPair = window.fastAuthController.findInKeyStores(`oidc_keypair_${this.oidcToken}`);
+    if (!existingKeyPair) {
+      await (window as any).fastAuthController.claimOidcToken(this.oidcToken);
+    }
 
     if (!window.fastAuthController.getAccountId()) {
       const accountId = await this.getAccountIdFromOidcToken();

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -7,7 +7,7 @@ import { useSearchParams } from 'react-router-dom/dist';
 import FastAuthController from './controller';
 import { fetchAccountIds } from '../api';
 import { safeGetLocalStorage } from '../utils';
-import { network, networkId } from '../utils/config';
+import { networkId } from '../utils/config';
 import { checkFirestoreReady, firebaseAuth } from '../utils/firebase';
 
 type AuthState = {

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -68,12 +68,7 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
             const oidcToken = await firebaseAuth.currentUser.getIdToken();
             if (window.fastAuthController.getLocalStoreKey(`oidc_keypair_${oidcToken}`)) {
               const recoveryPK = await window.fastAuthController.getUserCredential(oidcToken);
-              const accountIds = await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${recoveryPK}/accounts`)
-                .then((res) => res.json())
-                .catch((err) => {
-                  console.log(err);
-                  throw new Error('Unable to retrieve account Id');
-                });
+              const accountIds = await fetchAccountIds(recoveryPK);
               (window as any).fastAuthController = new FastAuthController({
                 accountId: accountIds[0],
                 networkId

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -19,6 +19,8 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
   const webauthnUsername = useMemo(() => safeGetLocalStorage('webauthn_username'), []);
   const [query] = useSearchParams();
   const email = query.get('email');
+  const successUrl = query.get('success_url');
+  const failureUrl = query.get('failure_url');
 
   if (webauthnUsername === undefined) {
     return { authenticated: new Error('Please allow third party cookies') };
@@ -86,12 +88,12 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
     handleAuthState()
       .catch((e) => {
         redirectWithError({
-          failure_url: query.get('failure_url'),
-          success_url: query.get('success_url'),
-          error: e.message,
+          failure_url: failureUrl,
+          success_url: successUrl,
+          error:       e.message,
         });
       });
-  }, [email, skipGetKeys, webauthnUsername]);
+  }, [email, skipGetKeys, webauthnUsername, successUrl, failureUrl]);
 
   return { authenticated };
 };

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -33,7 +33,7 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
         setAuthenticated(false);
       } else if (controllerState === true) {
         setAuthenticated(true);
-      } else if ((!webauthnUsername && isPasskeySupported)|| (email && email !== webauthnUsername)) {
+      } else if ((!webauthnUsername && isPasskeySupported) || (email && email !== webauthnUsername)) {
         setAuthenticated(false);
       } else if (isPasskeySupported) {
         try {

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -65,7 +65,7 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
       } else {
         checkFirestoreReady().then(async (isReady) => {
           if (isReady) {
-            const oidcToken = firebaseAuth.currentUser.getIdToken();
+            const oidcToken = await firebaseAuth.currentUser.getIdToken();
             if (window.fastAuthController.getLocalStoreKey(`oidc_keypair_${oidcToken}`)) {
               const recoveryPK = await window.fastAuthController.getUserCredential(oidcToken);
               const accountIds = await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${recoveryPK}/accounts`)

--- a/packages/near-fast-auth-signer/src/utils/index.ts
+++ b/packages/near-fast-auth-signer/src/utils/index.ts
@@ -42,3 +42,14 @@ export const safeGetLocalStorage = (key: string) => {
     return undefined;
   }
 };
+
+export const deleteOidcKeyPairOnLocalStorage = () => {
+  const itemCount = localStorage.length;
+  for (let i = 0; i < itemCount; i += 1) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith('near-api-js:keystore:oidc_keypair')) {
+      console.log(`removing ${key} from localStorage`);
+      localStorage.removeItem(key);
+    }
+  }
+};


### PR DESCRIPTION
This PR contains implementation to support FAK actions on non webauthn browser. 


<img width="773" alt="before" src="https://github.com/near/fast-auth-signer/assets/6027014/e6d12ecc-279e-4f1e-8b87-0e1d5a648bf9">
<img width="1467" alt="after" src="https://github.com/near/fast-auth-signer/assets/6027014/12395ad6-8fa0-4ec0-93c9-f71e249e1c3d">

Right now, if I were to execute non-authorised FAK action and pass it to `/sign` on mpc recovery service, it returns with above. 

