### PR TITLE
Update new testnet relayer url

### DIFF
--- a/packages/near-fast-auth-signer-e2e-tests/test-app/hooks/useWalletSelector.tsx
+++ b/packages/near-fast-auth-signer-e2e-tests/test-app/hooks/useWalletSelector.tsx
@@ -13,7 +13,7 @@ export default () => {
           setupFastAuthWallet({
             relayerUrl:
               networkId === 'testnet'
-                ? 'http://34.70.226.83:3030/relay'
+                ? 'https://near-relayer-testnet.api.pagoda.co/relay'
                 : 'https://near-relayer-mainnet.api.pagoda.co/relay',
           })
         ],

--- a/packages/near-fast-auth-signer-e2e-tests/test-app/hooks/useWalletSelector.tsx
+++ b/packages/near-fast-auth-signer-e2e-tests/test-app/hooks/useWalletSelector.tsx
@@ -13,7 +13,7 @@ export default () => {
           setupFastAuthWallet({
             relayerUrl:
               networkId === 'testnet'
-                ? 'https://near-relayer-testnet.api.pagoda.co/relay'
+                ? 'http://near-relayer-testnet.api.pagoda.co/relay'
                 : 'https://near-relayer-mainnet.api.pagoda.co/relay',
           })
         ],

--- a/packages/near-fast-auth-signer/webpack.config.js
+++ b/packages/near-fast-auth-signer/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
       FIREBASE_MESSAGING_SENDER_ID:         '829449955812',
       FIREBASE_APP_ID:                      '1:829449955812:web:532436aa35572be60abff1',
       FIREBASE_MEASUREMENT_ID:              'G-T2PPJ8QRYY',
-      RELAYER_URL_TESTNET:                  'https://near-relayer-testnet.api.pagoda.co/relay',
+      RELAYER_URL_TESTNET:                  'http://near-relayer-testnet.api.pagoda.co/relay',
       FIREBASE_API_KEY_TESTNET:             'AIzaSyDAh6lSSkEbpRekkGYdDM5jazV6IQnIZFU',
       FIREBASE_AUTH_DOMAIN_TESTNET:         'pagoda-oboarding-dev.firebaseapp.com',
       FIREBASE_PROJECT_ID_TESTNET:          'pagoda-oboarding-dev',

--- a/packages/near-fast-auth-signer/webpack.config.js
+++ b/packages/near-fast-auth-signer/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
       FIREBASE_MESSAGING_SENDER_ID:         '829449955812',
       FIREBASE_APP_ID:                      '1:829449955812:web:532436aa35572be60abff1',
       FIREBASE_MEASUREMENT_ID:              'G-T2PPJ8QRYY',
-      RELAYER_URL_TESTNET:                  'http://34.70.226.83:3030/relay',
+      RELAYER_URL_TESTNET:                  'https://near-relayer-testnet.api.pagoda.co/relay',
       FIREBASE_API_KEY_TESTNET:             'AIzaSyDAh6lSSkEbpRekkGYdDM5jazV6IQnIZFU',
       FIREBASE_AUTH_DOMAIN_TESTNET:         'pagoda-oboarding-dev.firebaseapp.com',
       FIREBASE_PROJECT_ID_TESTNET:          'pagoda-oboarding-dev',


### PR DESCRIPTION
Relayer URL for testnet has been updated a while ago but it hasn't been applied to this repo.

currently, test.near.org is pointing to old relayer api endpoint that no longer works. 