### PR TITLE
Remove account exist check

### DIFF
--- a/packages/near-fast-auth-signer/package.json
+++ b/packages/near-fast-auth-signer/package.json
@@ -65,6 +65,7 @@
     "styled-components": "^6.0.5",
     "ua-parser-js": "^1.0.35",
     "url": "^0.11.0",
+    "validator": "^13.11.0",
     "yup": "^1.3.3",
     "zustand": "^4.3.9"
   },

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -20,7 +20,7 @@ import {
   decodeIfTruthy, inIframe, redirectWithError
 } from '../../utils';
 import { basePath } from '../../utils/config';
-import { checkFirestoreReady, firebaseAuth, userExists } from '../../utils/firebase';
+import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
 
 const StyledContainer = styled.div`
   width: 100%;
@@ -108,9 +108,6 @@ function SignInPage() {
     const methodNames = searchParams.get('methodNames');
 
     try {
-      if (!await userExists(data.email)) {
-        throw new Error('Account not found, please create an account and try again');
-      }
       await handleCreateAccount({
         accountId:   null,
         email:       data.email,

--- a/packages/near-fast-auth-signer/src/components/CreateAccount/CreateAccount.tsx
+++ b/packages/near-fast-auth-signer/src/components/CreateAccount/CreateAccount.tsx
@@ -155,7 +155,6 @@ function CreateAccount() {
     const methodNames = searchParams.get('methodNames');
 
     try {
-      if (!isValid) return;
       const fullAccountId = `${data.username}.${network.fastAuth.accountIdSuffix}`;
       const {
         accountId
@@ -197,7 +196,7 @@ function CreateAccount() {
       //   title: message,
       // });
     }
-  }, [navigate, searchParams, isValid]);
+  }, [navigate, searchParams]);
 
   useEffect(() => {
     const email = searchParams.get('email');

--- a/packages/near-fast-auth-signer/src/components/CreateAccount/CreateAccount.tsx
+++ b/packages/near-fast-auth-signer/src/components/CreateAccount/CreateAccount.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
+import isEmail from 'validator/lib/isEmail';
 import * as yup from 'yup';
 
 import FormContainer from './styles/FormContainer';
@@ -13,7 +14,6 @@ import Input from '../../lib/Input/Input';
 import { openToast } from '../../lib/Toast';
 import { inIframe, redirectWithError } from '../../utils';
 import { network } from '../../utils/config';
-import { userExists } from '../../utils/firebase';
 import {
   accountAddressPatternNoSubAccount, getEmailId
 } from '../../utils/form-validation';
@@ -80,18 +80,13 @@ const schema = yup.object().shape({
     .string()
     .required('Email address is required')
     .test(
-      'is-email-available',
+      'is-email-valid',
       async (email, context) => {
         let message: string;
-
-        try {
-          if (email && await userExists(email)) {
-            message = `${email} is taken, try something else.`;
-          } else {
-            return true;
-          }
-        } catch {
+        if (!isEmail(email)) {
           message = 'Please enter a valid email address';
+        } else {
+          return true;
         }
 
         return context.createError({
@@ -160,6 +155,7 @@ function CreateAccount() {
     const methodNames = searchParams.get('methodNames');
 
     try {
+      if (!isValid) return;
       const fullAccountId = `${data.username}.${network.fastAuth.accountIdSuffix}`;
       const {
         accountId
@@ -201,7 +197,7 @@ function CreateAccount() {
       //   title: message,
       // });
     }
-  }, [navigate, searchParams]);
+  }, [navigate, searchParams, isValid]);
 
   useEffect(() => {
     const email = searchParams.get('email');

--- a/packages/near-fast-auth-signer/src/components/Login/Login.tsx
+++ b/packages/near-fast-auth-signer/src/components/Login/Login.tsx
@@ -48,18 +48,10 @@ function Login() {
   const emailCheck = async (
     params: { email: string }
   ) => {
-    try {
-      navigate({
-        pathname: '/add-device',
-        search:   `email=${params.email}`,
-      });
-    } catch (e) {
-      console.error('error', e);
-      openToast({
-        type:  'ERROR',
-        title: e.message,
-      });
-    }
+    navigate({
+      pathname: '/add-device',
+      search:   `email=${params.email}`,
+    });
   };
 
   return (

--- a/packages/near-fast-auth-signer/src/components/Login/Login.tsx
+++ b/packages/near-fast-auth-signer/src/components/Login/Login.tsx
@@ -7,7 +7,6 @@ import * as yup from 'yup';
 import { LoginWrapper } from './Login.style';
 import { Button } from '../../lib/Button';
 import Input from '../../lib/Input/Input';
-import { openToast } from '../../lib/Toast';
 
 const schema = yup.object().shape({
   email: yup

--- a/packages/near-fast-auth-signer/src/components/Login/Login.tsx
+++ b/packages/near-fast-auth-signer/src/components/Login/Login.tsx
@@ -8,7 +8,6 @@ import { LoginWrapper } from './Login.style';
 import { Button } from '../../lib/Button';
 import Input from '../../lib/Input/Input';
 import { openToast } from '../../lib/Toast';
-import { userExists } from '../../utils/firebase';
 
 const schema = yup.object().shape({
   email: yup
@@ -50,17 +49,10 @@ function Login() {
     params: { email: string }
   ) => {
     try {
-      if (await userExists(params.email)) {
-        navigate({
-          pathname: '/add-device',
-          search:   `email=${params.email}`,
-        });
-      } else {
-        navigate({
-          pathname: '/create-account',
-          search:   `email=${params.email}`,
-        });
-      }
+      navigate({
+        pathname: '/add-device',
+        search:   `email=${params.email}`,
+      });
     } catch (e) {
       console.error('error', e);
       openToast({

--- a/packages/near-fast-auth-signer/src/utils/firebase.ts
+++ b/packages/near-fast-auth-signer/src/utils/firebase.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { initializeApp } from 'firebase/app';
-import { getAuth, fetchSignInMethodsForEmail } from 'firebase/auth';
+import { getAuth } from 'firebase/auth';
 
 import { network } from './config';
 
@@ -15,13 +15,3 @@ export const checkFirestoreReady = async () => firebaseAuth.authStateReady()
     }
     return false;
   });
-
-/**
- * Checks if a user exists in the Firebase authentication system.
- * @param {string} email - The email of the user to check.
- * @returns {Promise<boolean>} - A promise that resolves to true if the user exists, false otherwise.
- */
-export const userExists = async (email: string): Promise<boolean> => {
-  const signInMethods = await fetchSignInMethodsForEmail(firebaseAuth, email);
-  return signInMethods.length > 0;
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10171,6 +10171,11 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
+validator@^13.11.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
This PR contains implementation for supporting `enable  email enumeration protection` on firebase. 

This change is part of security improvement where this change will stop from hackers to see if specific email is being used on fast-auth or not. 

From this change, regardless of email registered or not, it will trigger verify email check. If someone uses a specific email without create account first, it will still send email with verification link, but after link is being clicked, it will return with error:

![image](https://github.com/near/fast-auth-signer/assets/6027014/5aa52ad7-46ea-4761-b6db-d3a16f6cb68b)

In terms of post merge, we need to land this PR to production prior to enabling the configuration on firebase console. 