### PR TITLE
Improve on account id retrival

### DIFF
--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -10,25 +10,15 @@ import {
  *
  * @param publicKey - The public key to fetch the account IDs for.
  * @param options - An object containing the following properties:
- * - skipCache: A boolean indicating whether to skip the cache and fetch the account IDs from the external source.
  * - returnEmpty: A boolean indicating whether to return an empty array if no account IDs are found.
  * @returns A promise that resolves to an array of account IDs.
  * @throws Will throw an error if the fetch request fails.
  */
 
 type Option= {
-  skipCache?: boolean;
   returnEmpty?: boolean;
 }
 export const fetchAccountIds = async (publicKey: string, options?: Option): Promise<string[]> => {
-  if (window.fastAuthController && !options?.skipCache) {
-    const cachedAccountIds = await window.fastAuthController.getAccounts();
-
-    if (cachedAccountIds.length) {
-      return cachedAccountIds;
-    }
-  }
-
   // retrieve from firebase
   let accountIds = [];
   if (publicKey) {

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -13,16 +13,18 @@ import {
  * @throws Will throw an error if the fetch request fails.
  */
 export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
-  const res = await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`);
-  if (!res.ok) {
-    throw new Error(`HTTP error! status: ${res.status}`);
+  let accountIds: string[] = [];
+  if (publicKey) {
+    const accountId = await window.firestoreController.getAccountIdByPublicKey(publicKey);
+    accountIds = accountId ? [accountId] : [];
   }
 
-  let accountIds: string[] = await res.json();
-
   if (accountIds.length === 0) {
-    const accountId = await window.firestoreController.getAccountIdByPublicKey(publicKey);
-    accountIds =  accountId ? [accountId] : [];
+    const res = await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`);
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+    accountIds = await res.json();
   }
 
   if (accountIds.length === 0) {

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -258,6 +258,7 @@ function SignInPage() {
         // once it has email but not authenicated, it means existing passkey is not valid anymore, therefore remove webauthn_username and try to create a new passkey
         window.localStorage.removeItem('webauthn_username');
         addDevice({ email });
+        window.fastAuthController.setAccountId('');
       }
     };
 

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -102,7 +102,8 @@ export const onSignIn = async ({
   gateway,
 }) => {
   const recoveryPK = await window.fastAuthController.getUserCredential(accessToken);
-  const accountIds = await fetchAccountIds(recoveryPK);
+  const cachedAccountIds = await window.fastAuthController.getAccounts();
+  const accountIds = cachedAccountIds.length ? cachedAccountIds : await fetchAccountIds(recoveryPK);
 
   if (!accountIds.length) {
     throw new Error('Account not found, please create an account and try again');

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -102,8 +102,7 @@ export const onSignIn = async ({
   gateway,
 }) => {
   const recoveryPK = await window.fastAuthController.getUserCredential(accessToken);
-  const cachedAccountIds = await window.fastAuthController.getAccounts();
-  const accountIds = cachedAccountIds.length ? cachedAccountIds : await fetchAccountIds(recoveryPK);
+  const accountIds = await fetchAccountIds(recoveryPK, { returnEmpty: true });
 
   if (!accountIds.length) {
     throw new Error('Account not found, please create an account and try again');

--- a/packages/near-fast-auth-signer/src/lib/firestoreController.ts
+++ b/packages/near-fast-auth-signer/src/lib/firestoreController.ts
@@ -34,8 +34,8 @@ class FirestoreController {
 
   async getAccountIdFromOidcToken() {
     const recoveryPK = await window.fastAuthController.getUserCredential(this.oidcToken);
-    const accountIds = await fetchAccountIds(recoveryPK);
-
+    const cachedAccountIds = await window.fastAuthController.getAccounts();
+    const accountIds = cachedAccountIds.length ? cachedAccountIds : await fetchAccountIds(recoveryPK);
     if (!accountIds.length) {
       const noAccountIdError = new Error('Unable to retrieve account Id');
       captureException(noAccountIdError);

--- a/packages/near-fast-auth-signer/src/lib/firestoreController.ts
+++ b/packages/near-fast-auth-signer/src/lib/firestoreController.ts
@@ -34,8 +34,7 @@ class FirestoreController {
 
   async getAccountIdFromOidcToken() {
     const recoveryPK = await window.fastAuthController.getUserCredential(this.oidcToken);
-    const cachedAccountIds = await window.fastAuthController.getAccounts();
-    const accountIds = cachedAccountIds.length ? cachedAccountIds : await fetchAccountIds(recoveryPK);
+    const accountIds = await fetchAccountIds(recoveryPK);
     if (!accountIds.length) {
       const noAccountIdError = new Error('Unable to retrieve account Id');
       captureException(noAccountIdError);

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -42,7 +42,7 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
           const keypairs = await getKeys(webauthnUsername);
           const accounts = await Promise.allSettled(
             keypairs.map(async (k) => {
-              const accIds = await fetchAccountIds(k.getPublicKey().toString());
+              const accIds = await fetchAccountIds(k.getPublicKey().toString(), { skipCache: true, returnEmpty: true });
               return accIds.map((accId) => { return { accId, keyPair: k }; });
             })
           );

--- a/packages/near-fast-auth-signer/src/lib/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/lib/useAuthState.ts
@@ -42,7 +42,7 @@ export const useAuthState = (skipGetKeys = false): AuthState => {
           const keypairs = await getKeys(webauthnUsername);
           const accounts = await Promise.allSettled(
             keypairs.map(async (k) => {
-              const accIds = await fetchAccountIds(k.getPublicKey().toString(), { skipCache: true, returnEmpty: true });
+              const accIds = await fetchAccountIds(k.getPublicKey().toString(), { returnEmpty: true });
               return accIds.map((accId) => { return { accId, keyPair: k }; });
             })
           );


### PR DESCRIPTION
This PR contains improvement on fetching account id from public key. 
1. Attempt to check with firebase first instead of kitwallet
2. Attempt to retrieve cached account id first before calling external source.

Background:
Currently the performance of the kitwallet is non-deterministic and we rather checks for firebase first and if there is no record, it will return response much quicker than kit wallet so overall it will improve UX. 
