### PR TITLE
Check for window.firestoreController first before execution

### DIFF
--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -22,9 +22,11 @@ export const fetchAccountIds = async (publicKey: string, options?: Option): Prom
   // retrieve from firebase
   let accountIds = [];
   if (publicKey) {
-    const accountId = await window.firestoreController.getAccountIdByPublicKey(publicKey);
-    if (accountId) {
-      return [accountId];
+    if (window.firestoreController) {
+      const accountId = await window.firestoreController.getAccountIdByPublicKey(publicKey);
+      if (accountId) {
+        return [accountId];
+      }
     }
     // retrieve from kitwallet
     const res = await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`);


### PR DESCRIPTION
This PR contains small fix for the situation where the app attempt to use `getAccountIdByPublicKey` before `window.firestoreController` is ready