### PR TITLE
Improve account id fetch with race condition

### DIFF
--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -5,15 +5,8 @@ import { network } from '../utils/config';
 import {
   CLAIM, getUserCredentialsFrpSignature
 } from '../utils/mpc-service';
+import { withTimeout } from '../utils';
 
-// Use this function to implement wait logic for async process
-const withTimeout = async (promise, timeoutMs) => {
-  // Create a promise that resolves with false after timeoutMs milliseconds
-  const timeoutPromise = new Promise((resolve) => { setTimeout(() => resolve(false), timeoutMs); });
-
-  // Race the input promise against the timeout
-  return Promise.race([promise, timeoutPromise]);
-};
 
 /**
  * Fetches the account IDs associated with a given public key.

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/react';
 import { KeyPair } from 'near-api-js';
 
 import { network } from '../utils/config';
@@ -31,14 +32,18 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
       }
     }
 
-    return withTimeout(await fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`), KIT_WALLET_WAIT_DURATION)
-      .then(async (res) => {
-        if (res) {
-          const ids = await res.json();
-          return ids;
-        }
-        return [];
-      });
+    try {
+      const res = await withTimeout(fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`), KIT_WALLET_WAIT_DURATION);
+      if (res) {
+        const ids = await res.json();
+        return ids;
+      }
+      return [];
+    } catch (error) {
+      console.log('fetchAccountIds', error);
+      captureException(error);
+      return [];
+    }
   }
 
   return [];

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -1,12 +1,11 @@
 import { captureException } from '@sentry/react';
 import { KeyPair } from 'near-api-js';
 
+import { withTimeout } from '../utils';
 import { network } from '../utils/config';
 import {
   CLAIM, getUserCredentialsFrpSignature
 } from '../utils/mpc-service';
-import { withTimeout } from '../utils';
-
 
 /**
  * Fetches the account IDs associated with a given public key.

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { createNEARAccount, fetchAccountIds } from '../../api';
-import FastAuthController from '../../lib/controller';
+import { setAccountIdToController } from '../../lib/controller';
 import FirestoreController from '../../lib/firestoreController';
 import {
   decodeIfTruthy, inIframe, isUrlNotJavascriptProtocol, redirectWithError
@@ -227,16 +227,7 @@ function AuthCallbackPage() {
           const accessToken = await user.getIdToken();
 
           setStatusMessage(isRecovery ? 'Recovering account...' : 'Creating account...');
-
-          // claim the oidc token
-          if (window.fastAuthController) {
-            window.fastAuthController.setAccountId(accountId);
-          } else {
-            window.fastAuthController = new FastAuthController({
-              accountId,
-              networkId
-            });
-          }
+          setAccountIdToController({ accountId, networkId });
 
           let publicKeyFak: string;
 

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -102,8 +102,7 @@ export const onSignIn = async ({
 }) => {
   // Stop from LAK with multi-chain contract
   const recoveryPK = await window.fastAuthController.getUserCredential(accessToken);
-  const accountIds = await fetchAccountIds(recoveryPK, { returnEmpty: true });
-
+  const accountIds = await fetchAccountIds(recoveryPK);
   // TODO: If we want to remove old LAK automatically, use below code and add deleteKeyActions to signAndSendActionsWithRecoveryKey
   // const existingDevice = await window.firestoreController.getDeviceCollection(publicKeyFak);
   // // delete old lak key attached to webAuthN public Key
@@ -230,10 +229,14 @@ function AuthCallbackPage() {
           setStatusMessage(isRecovery ? 'Recovering account...' : 'Creating account...');
 
           // claim the oidc token
-          window.fastAuthController = new FastAuthController({
-            accountId,
-            networkId
-          });
+          if (window.fastAuthController) {
+            window.fastAuthController.setAccountId(accountId);
+          } else {
+            window.fastAuthController = new FastAuthController({
+              accountId,
+              networkId
+            });
+          }
 
           let publicKeyFak: string;
 
@@ -249,7 +252,9 @@ function AuthCallbackPage() {
 
           await window.fastAuthController.claimOidcToken(accessToken);
           const oidcKeypair = await window.fastAuthController.getKey(`oidc_keypair_${accessToken}`);
-          window.firestoreController = new FirestoreController();
+          if (!window.firestoreController) {
+            window.firestoreController = new FirestoreController();
+          }
           window.firestoreController.updateUser({
             userUid:   user.uid,
             oidcToken: accessToken,

--- a/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom/dist';
 
 import { fetchAccountIdsFromTwoKeys } from '../api';
-import FastAuthController from '../lib/controller';
+import FastAuthController, { setAccountIdToController } from '../lib/controller';
 import { safeGetLocalStorage } from '../utils';
 import { networkId } from '../utils/config';
 import { checkFirestoreReady, firebaseAuth } from '../utils/firebase';
@@ -57,14 +57,10 @@ export const getAuthState = async (email?: string | null): Promise<AuthState> =>
 
         if (!account) return false;
 
-        if (window.fastAuthController) {
-          window.fastAuthController.setAccountId(account?.accountId);
-        } else {
-          window.fastAuthController = new FastAuthController({
-            accountId: account?.accountId,
-            networkId
-          });
-        }
+        setAccountIdToController({
+          accountId: account?.accountId,
+          networkId
+        });
 
         return true;
       }

--- a/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
@@ -4,7 +4,7 @@ import { captureException } from '@sentry/react';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom/dist';
 
-import { fetchAccountIds } from '../api';
+import { fetchAccountIdsFromTwoKeys } from '../api';
 import FastAuthController from '../lib/controller';
 import { safeGetLocalStorage } from '../utils';
 import { networkId } from '../utils/config';
@@ -28,26 +28,25 @@ export const getAuthState = async (email?: string | null): Promise<AuthState> =>
       return false;
     } if (isPasskeySupported && webauthnUsername) {
       const keypairs = await getKeys(webauthnUsername);
-      const accounts = await Promise.allSettled(
-        keypairs.map(async (k) => {
-          const accIds = await fetchAccountIds(k.getPublicKey().toString(), { returnEmpty: true });
-          return accIds.map((accId) => { return { accId, keyPair: k }; });
-        })
+      const accountInfo = await fetchAccountIdsFromTwoKeys(
+        keypairs[0].getPublicKey().toString(),
+        keypairs[1].getPublicKey().toString(),
       );
 
-      const accountsList = accounts
-        .flatMap((result) => (result.status === 'fulfilled' ? result.value : []));
-
-      if (accountsList.length === 0) {
+      if (!accountInfo.accId) {
         return false;
       }
 
-      window.fastAuthController = new FastAuthController({
-        accountId: accountsList[0].accId,
-        networkId
-      });
+      if (!window.fastAuthController) {
+        window.fastAuthController = new FastAuthController({
+          accountId: accountInfo.accId,
+          networkId
+        });
+      } else {
+        window.fastAuthController.setAccountId(accountInfo.accId);
+      }
 
-      await window.fastAuthController.setKey(new KeyPairEd25519(accountsList[0].keyPair.toString().split(':')[1]));
+      await window.fastAuthController.setKey(new KeyPairEd25519(accountInfo.publicKey.split(':')[1]));
       return true;
     } if (isFirestoreReady && firebaseAuth.currentUser) {
       const oidcToken = await firebaseAuth.currentUser.getIdToken();
@@ -58,10 +57,15 @@ export const getAuthState = async (email?: string | null): Promise<AuthState> =>
 
         if (!account) return false;
 
-        window.fastAuthController = new FastAuthController({
-          accountId: account?.accountId,
-          networkId
-        });
+        if (window.fastAuthController) {
+          window.fastAuthController.setAccountId(account?.accountId);
+        } else {
+          window.fastAuthController = new FastAuthController({
+            accountId: account?.accountId,
+            networkId
+          });
+        }
+
         return true;
       }
     }

--- a/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom/dist';
 
 import { fetchAccountIdsFromTwoKeys } from '../api';
-import FastAuthController, { setAccountIdToController } from '../lib/controller';
+import { setAccountIdToController } from '../lib/controller';
 import { safeGetLocalStorage } from '../utils';
 import { networkId } from '../utils/config';
 import { checkFirestoreReady, firebaseAuth } from '../utils/firebase';
@@ -37,14 +37,10 @@ export const getAuthState = async (email?: string | null): Promise<AuthState> =>
         return false;
       }
 
-      if (!window.fastAuthController) {
-        window.fastAuthController = new FastAuthController({
-          accountId: accountInfo.accId,
-          networkId
-        });
-      } else {
-        window.fastAuthController.setAccountId(accountInfo.accId);
-      }
+      setAccountIdToController({
+        accountId: accountInfo.accId,
+        networkId,
+      });
 
       await window.fastAuthController.setKey(new KeyPairEd25519(accountInfo.publicKey.split(':')[1]));
       return true;

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -101,8 +101,9 @@ class FastAuthController {
     return new KeyPairEd25519(privKeyStr.split(':')[1]);
   }
 
-  async getKey(accountId?: string) {
-    return this.keyStore.getKey(this.networkId, accountId || this.accountId);
+  async getKey(key?: string) {
+    const keypair = await this.keyStore.getKey(this.networkId, key || this.accountId);
+    return keypair;
   }
 
   async setKey(keyPair) {
@@ -214,7 +215,7 @@ class FastAuthController {
       headers: new Headers({ 'Content-Type': 'application/json' }),
     }).catch((err) => {
       console.log('Unable to sign and send delegate action', err);
-      captureException(err);
+      captureException(`Unable to sign and send delegate action, ${err.toString()}`);
     });
   }
 
@@ -430,7 +431,7 @@ class FastAuthController {
       headers: new Headers({ 'Content-Type': 'application/json' }),
     }).catch((err) => {
       console.log('Unable to sign and send action with recovery key', err);
-      captureException(err);
+      captureException(`Unable to sign and send action with recovery key, ${err.toString()}`);
     });
   }
 

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -468,3 +468,14 @@ class FastAuthController {
 }
 
 export default FastAuthController;
+
+export const setAccountIdToController = ({ accountId, networkId }) => {
+  if (window.fastAuthController) {
+    window.fastAuthController.setAccountId(accountId);
+  } else {
+    window.fastAuthController = new FastAuthController({
+      accountId,
+      networkId
+    });
+  }
+};

--- a/packages/near-fast-auth-signer/src/utils/index.ts
+++ b/packages/near-fast-auth-signer/src/utils/index.ts
@@ -77,3 +77,12 @@ export const deleteOidcKeyPairOnLocalStorage = () => {
 export const assertNever = (x: never): never => {
   throw new Error(`Unexpected object: ${x}`);
 };
+
+// Use this function to implement wait logic for async process
+export const withTimeout = async (promise, timeoutMs) => {
+  // Create a promise that resolves with false after timeoutMs milliseconds
+  const timeoutPromise = new Promise((resolve) => { setTimeout(() => resolve(false), timeoutMs); });
+
+  // Race the input promise against the timeout
+  return Promise.race([promise, timeoutPromise]);
+};


### PR DESCRIPTION
This PR contains implementation for improve UX of fetching account id. 

As part of using web-authN passkey, we always given two sets of key-pairs and only one of them are genuine. We find the true one by checking its public key presence on firebase (main) AND kitwallet (fallback). The issue was that on previous implementation, we use `Promise.allSettled` to wait for both keys to be finished with checking with firebase + kitwallet. But the problem here is that, one of the key is falsy, in which it does not exist in firebase store, and therefore always hit kitwallet. As of now, kitwallet is the bottleneck of UX where it often takes VERY long to process or sometimes returns invalid result. Its performance is non-deterministic and ideally we should avoid depending on it as much as possible for now. 

Solution on this PR is by having `Promise.race` to grap what gets returned first. Right now, out of given two keys, time taken to get genuine key is ALWAYS faster so once we receive it, we check for response with presence of account Id. If present, we return immediately, otherwise we also checks for second key just in case (but only if first one returns with empty)

Also there is an improvement on `fetchAccountIds` where it also uses `Promise.race` with wait duration of 10 seconds on kit wallet to response. If it doesn't return within 10 seconds, it will consider it as falsy and return empty. (If so, user will be redirected to email verification flow)

These changes will resolve one of two major bottleneck of fast-auth experience. 