### PR TITLE
feat: make `relayerUrl` optional

### DIFF
--- a/packages/near-fast-auth-signer/src/utils/multi-chain/chains/Bitcoin/Bitcoin.ts
+++ b/packages/near-fast-auth-signer/src/utils/multi-chain/chains/Bitcoin/Bitcoin.ts
@@ -55,14 +55,14 @@ export class Bitcoin {
 
   private providerUrl: string;
 
-  private relayerUrl: string;
+  private relayerUrl?: string;
 
   private contract: ChainSignatureContracts;
 
   constructor(config: {
     networkType: NetworkType;
     providerUrl: string;
-    relayerUrl: string,
+    relayerUrl?: string,
     contract: ChainSignatureContracts
   }) {
     this.network =      config.networkType === 'testnet'
@@ -362,8 +362,8 @@ export class Bitcoin {
           transactionHash,
           path,
           nearAuthentication,
-          this.relayerUrl,
-          this.contract
+          this.contract,
+          this.relayerUrl
         );
 
         if (!signature) {

--- a/packages/near-fast-auth-signer/src/utils/multi-chain/chains/Bitcoin/types.ts
+++ b/packages/near-fast-auth-signer/src/utils/multi-chain/chains/Bitcoin/types.ts
@@ -29,7 +29,7 @@ export type BitcoinRequest = {
   transaction: BTCTransaction;
   chainConfig: BTCChainConfigWithProviders;
   nearAuthentication: NearAuthentication;
-  fastAuthRelayerUrl: string;
+  fastAuthRelayerUrl?: string;
 };
 
 export type BTCNetworks = 'mainnet' | 'testnet';

--- a/packages/near-fast-auth-signer/src/utils/multi-chain/chains/EVM/EVM.ts
+++ b/packages/near-fast-auth-signer/src/utils/multi-chain/chains/EVM/EVM.ts
@@ -10,7 +10,7 @@ import { ChainSignatureContracts, NearAuthentication, NearNetworkIds } from '../
 class EVM {
   private provider: ethers.JsonRpcProvider;
 
-  private relayerUrl: string;
+  private relayerUrl?: string;
 
   private contract: ChainSignatureContracts;
 
@@ -22,7 +22,7 @@ class EVM {
    * @param {string} config.relayerUrl - The URL of the relayer service.
    * @param {ChainSignatureContracts} config.contract - The contract identifier for chain signature operations.
    */
-  constructor(config: { providerUrl: string; relayerUrl: string, contract: ChainSignatureContracts }) {
+  constructor(config: { providerUrl: string; relayerUrl?: string, contract: ChainSignatureContracts }) {
     this.provider = new ethers.JsonRpcProvider(config.providerUrl);
     this.relayerUrl = config.relayerUrl;
     this.contract = config.contract;
@@ -197,8 +197,8 @@ class EVM {
       transactionHash,
       path,
       nearAuthentication,
-      this.relayerUrl,
-      this.contract
+      this.contract,
+      this.relayerUrl
     );
 
     if (signature) {

--- a/packages/near-fast-auth-signer/src/utils/multi-chain/chains/EVM/types.ts
+++ b/packages/near-fast-auth-signer/src/utils/multi-chain/chains/EVM/types.ts
@@ -20,5 +20,5 @@ export type EVMRequest = {
   transaction: EVMTransaction;
   chainConfig: EVMChainConfigWithProviders;
   nearAuthentication: NearAuthentication;
-  fastAuthRelayerUrl: string;
+  fastAuthRelayerUrl?: string;
 };


### PR DESCRIPTION
Make `relayerUrl` optional on the multichain toolkit module so that it can be used with non fast auth accounts. This is necessary because the meta transaction relayer will only cover gas for fast auth accounts:

> For the fastauth relayer, the account needs to have an allowance in redis initialized by calling /create_account_atomic . This means that unless the account has been registered, the fastauth meta transaction relayer will not cover gas for any account




