### PR TITLE
fix: avoid multiple passkey prompts and sign in event logs

### DIFF
--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -371,7 +371,11 @@ function AddDevicePage() {
             input: 'add-device-email',
           }}
           onFocus={async () => {
-            if (!wasPassKeyPrompted && await isPassKeyAvailable()) {
+            if (
+              !wasPassKeyPrompted
+              && decodeIfTruthy(searchParams.get('forceNoPasskey')) !== true
+              && (await isPassKeyAvailable())
+            ) {
               setInFlight(true);
               const authenticated = await getAuthState();
               setWasPassKeyPrompted(true);

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -26,9 +26,34 @@ import {
 import { recordEvent } from '../../utils/analytics';
 import { basePath } from '../../utils/config';
 import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
+import ErrorSvg from '../CreateAccount/icons/ErrorSvg';
 import { FormContainer, StyledContainer } from '../Layout';
 import { Separator, SeparatorWrapper } from '../Login/Login.style';
 import { getMultiChainContract } from '../SignMultichain/utils';
+
+const ErrorContainer = styled.div`
+.stats-message {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  span {
+    flex: 1;
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &.error {
+    color: #a81500;
+  }
+
+  &.success {
+    color: #197650;
+  }
+}
+`;
 
 export const handleCreateAccount = async ({
   accountId, email, isRecovery, success_url, failure_url, public_key, contract_id, methodNames
@@ -85,6 +110,7 @@ function AddDevicePage() {
     email: searchParams.get('email') ?? '',
   };
   const [wasPassKeyPrompted, setWasPassKeyPrompted] = useState(false);
+  const [passkeyAuthError, setPasskeyAuthError] = useState(false);
   const {
     register, handleSubmit, setValue, getValues, formState: { errors }
   } = useForm({
@@ -343,6 +369,8 @@ function AddDevicePage() {
     }, '*');
   };
 
+  console.log(getValues().email, '<<< email');
+
   return (
     <StyledContainer inIframe={inIframe()}>
       <AddDeviceForm
@@ -380,6 +408,7 @@ function AddDevicePage() {
               if (authenticated === true) {
                 await handleAuthCallback();
               } else {
+                setPasskeyAuthError(true);
                 setInFlight(false);
               }
             }
@@ -414,7 +443,14 @@ function AddDevicePage() {
           iconLeft="bi bi-wallet"
           onClick={handleConnectWallet}
         />
-
+        {!getValues().email && passkeyAuthError && !errors.email?.message ? (
+          <ErrorContainer>
+            <div className="stats-message error">
+              <ErrorSvg />
+              <span>Failed to authenticate, please retry with email</span>
+            </div>
+          </ErrorContainer>
+        ) : null}
       </AddDeviceForm>
     </StyledContainer>
   );

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -369,8 +369,6 @@ function AddDevicePage() {
     }, '*');
   };
 
-  console.log(getValues().email, '<<< email');
-
   return (
     <StyledContainer inIframe={inIframe()}>
       <AddDeviceForm

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -21,7 +21,7 @@ import FirestoreController from '../../lib/firestoreController';
 import Input from '../../lib/Input/Input';
 import { openToast } from '../../lib/Toast';
 import {
-  decodeIfTruthy, inIframe, isUrlNotJavascriptProtocol, safeGetLocalStorage
+  decodeIfTruthy, inIframe, isUrlNotJavascriptProtocol
 } from '../../utils';
 import { recordEvent } from '../../utils/analytics';
 import { basePath } from '../../utils/config';

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -84,6 +84,7 @@ function AddDevicePage() {
   const defaultValues = {
     email: searchParams.get('email') ?? '',
   };
+  const [wasPassKeyPrompted, setWasPassKeyPrompted] = useState(false);
   const {
     register, handleSubmit, setValue, getValues, formState: { errors }
   } = useForm({
@@ -164,7 +165,7 @@ function AddDevicePage() {
       return;
     }
     const publicKeyFak = isPasskeySupported ? await window.fastAuthController.getPublicKey() : '';
-    const existingDevice = isPasskeySupported
+    const existingDevice = isPasskeySupported && firebaseUser
       ? await window.firestoreController.getDeviceCollection(publicKeyFak)
       : null;
     const existingDeviceLakKey = existingDevice?.publicKeys?.filter((key) => key !== publicKeyFak)[0];
@@ -369,11 +370,15 @@ function AddDevicePage() {
           dataTest={{
             input: 'add-device-email',
           }}
-          onClick={async () => {
-            if (await isPassKeyAvailable()) {
+          onFocus={async () => {
+            if (!wasPassKeyPrompted && await isPassKeyAvailable()) {
+              setInFlight(true);
               const authenticated = await getAuthState();
+              setWasPassKeyPrompted(true);
               if (authenticated === true) {
                 await handleAuthCallback();
+              } else {
+                setInFlight(false);
               }
             }
           }}

--- a/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
+++ b/packages/near-fast-auth-signer/src/components/AddDevice/AddDevice.tsx
@@ -105,8 +105,6 @@ function AddDevicePage() {
 
     // if different user is logged in, sign out
     await firebaseAuth.signOut();
-    // once it has email but not authenticated, it means existing passkey is not valid anymore, therefore remove webauthn_username and try to create a new passkey
-    window.localStorage.removeItem('webauthn_username');
 
     const success_url = searchParams.get('success_url');
     const failure_url = searchParams.get('failure_url');
@@ -325,7 +323,7 @@ function AddDevicePage() {
         try {
           const isPasskeySupported = await isPassKeyAvailable();
           if (isPasskeySupported) {
-            setValue('email', safeGetLocalStorage('webauthn_username') ?? defaultValues.email);
+            setValue('email', defaultValues.email);
           }
         } catch (e) {
           setValue('email', defaultValues.email);

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -37,7 +37,6 @@ const onCreateAccount = async ({
   methodNames,
   success_url,
   setStatusMessage,
-  email,
   gateway,
 }) => {
   const res = await createNEARAccount({
@@ -90,7 +89,6 @@ export const onSignIn = async ({
   methodNames,
   setStatusMessage,
   success_url,
-  email,
   searchParams,
   navigate,
   gateway,

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -251,7 +251,6 @@ function AuthCallbackPage() {
             methodNames,
             success_url,
             setStatusMessage,
-            email,
             navigate,
             searchParams,
             gateway:      success_url,

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -65,11 +65,6 @@ const onCreateAccount = async ({
 
   setStatusMessage('Account created successfully!');
 
-  // TODO: Check if account ID matches the one from email
-  if (publicKeyFak) {
-    window.localStorage.setItem('webauthn_username', email);
-  }
-
   setStatusMessage('Redirecting to app...');
 
   const recoveryPK = await window.fastAuthController.getUserCredential(accessToken);
@@ -147,10 +142,6 @@ export const onSignIn = async ({
         });
 
         setStatusMessage('Account recovered successfully!');
-
-        if (publicKeyFak) {
-          window.localStorage.setItem('webauthn_username', email);
-        }
 
         setStatusMessage('Redirecting to app...');
 

--- a/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
+++ b/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
@@ -142,6 +142,7 @@ function Devices() {
   }, []);
 
   const redirectToSignin = () => {
+    searchParams.append('forceNoPasskey', 'true');
     if (inIframe()) {
       window.open(`${window.location.origin}${basePath ? `/${basePath}` : ''}/login?${searchParams.toString()}`, '_parent');
     } else {

--- a/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
+++ b/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
@@ -172,7 +172,6 @@ function Devices() {
         if (contract_id && public_key_lak) {
           setIsAddingKey(true);
 
-          const email = window.localStorage.getItem('emailForSignIn');
           const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
           const success_url = decodeIfTruthy(searchParams.get('success_url'));
           const oidcToken = window.firestoreController.getUserOidcToken();

--- a/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
+++ b/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
@@ -144,6 +144,14 @@ function Devices() {
   const redirectToSignin = () => {
     searchParams.append('forceNoPasskey', 'true');
     if (inIframe()) {
+      window.parent.postMessage({
+        type:   'method',
+        method: 'query',
+        id:     1234,
+        params: {
+          request_type: 'complete_authentication'
+        }
+      }, '*');
       window.open(`${window.location.origin}${basePath ? `/${basePath}` : ''}/login?${searchParams.toString()}`, '_parent');
     } else {
       navigate({

--- a/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
+++ b/packages/near-fast-auth-signer/src/components/Devices/Devices.tsx
@@ -184,7 +184,6 @@ function Devices() {
             methodNames,
             setStatusMessage: () => null,
             success_url,
-            email,
             searchParams,
             navigate,
             gateway:          success_url,

--- a/packages/near-fast-auth-signer/src/components/RpcRoute/RpcRoute.tsx
+++ b/packages/near-fast-auth-signer/src/components/RpcRoute/RpcRoute.tsx
@@ -10,23 +10,20 @@ function RpcRoute() {
         switch (e.data.params.request_type) {
           case 'get_pre_biometric_auth_account':
             try {
-              let username = window.localStorage.getItem('webauthn_username');
-              if (!username) {
-                username = await checkFirestoreReady().then(async (isReady) => {
-                  if (isReady) {
-                    const oidcToken = await firebaseAuth.currentUser.getIdToken();
-                    if (
-                      window.fastAuthController.getLocalStoreKey(
-                        `oidc_keypair_${oidcToken}`
-                      )
-                    ) {
-                      return firebaseAuth.currentUser.email;
-                    }
-                    return null;
+              const username = await checkFirestoreReady().then(async (isReady) => {
+                if (isReady) {
+                  const oidcToken = await firebaseAuth.currentUser.getIdToken();
+                  if (
+                    window.fastAuthController.getLocalStoreKey(
+                      `oidc_keypair_${oidcToken}`
+                    )
+                  ) {
+                    return firebaseAuth.currentUser.email;
                   }
                   return null;
-                });
-              }
+                }
+                return null;
+              });
               window.parent.postMessage({
                 type:   'response',
                 id:     e.data.id,

--- a/packages/near-fast-auth-signer/src/lib/controller.ts
+++ b/packages/near-fast-auth-signer/src/lib/controller.ts
@@ -116,7 +116,6 @@ class FastAuthController {
 
   async clearUser() {
     await this.keyStore.clear();
-    window.localStorage.removeItem('webauthn_username');
   }
 
   async isSignedIn() {


### PR DESCRIPTION
Adds:

- On click of the email address input on the login form, prompt for passkey. If provided log the user in immediately if not send email after they fill in the address and click the submit button

Fixes:

-  Remove duplication of event `click-login-continue`. Duplication happens when email is send due to manual `onSubmit` trigger after redirect
- Passkey is prompted twice when email is sent currently due to no longer using `webauthn_username`