### PR TITLE
fix: slash prefix to config.js

### DIFF
--- a/packages/near-fast-auth-signer/public/index.html
+++ b/packages/near-fast-auth-signer/public/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="config.js"></script>
+    <script src="/config.js"></script>
 </head>
 <body>
 <div id="root"></div>


### PR DESCRIPTION
Add `/` so runtime configs are always loaded from root path