### PR TITLE
Initial implementation of fast-near on fetchAccountIds

### DIFF
--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -29,7 +29,9 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
       const res = await fetch(`${network.fastAuth.fastnearUrl}/public_key/${publicKey}`);
       if (res) {
         const response = await res.json();
-        return response.account_ids;
+        if (response && response.account_ids && response.account_ids.length > 0) {
+          return response.account_ids;
+        }
       }
     }
 

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -26,12 +26,16 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
 
     // Currently fast near only support mainnet, once it supports testnet, we need to update this condition
     if (networkId === 'mainnet') {
-      const res = await fetch(`${network.fastAuth.fastnearUrl}/public_key/${publicKey}`);
-      if (res) {
-        const response = await res.json();
-        if (response && response.account_ids && response.account_ids.length > 0) {
-          return response.account_ids;
+      try {
+        const res = await fetch(`${network.fastAuth.fastnearUrl}/public_key/${publicKey}`);
+        if (res) {
+          const response = await res.json();
+          if (response && response.account_ids && response.account_ids.length > 0) {
+            return response.account_ids;
+          }
         }
+      } catch (error) {
+        console.log('Fail to retrieve account id from fast near:', error);
       }
     }
 

--- a/packages/near-fast-auth-signer/src/utils/config.ts
+++ b/packages/near-fast-auth-signer/src/utils/config.ts
@@ -16,6 +16,7 @@ export const networks: Record<NetworkId, Network> = {
     fastAuth:      {
       mpcRecoveryUrl:  'https://near-mpc-recovery-mainnet.api.pagoda.co',
       authHelperUrl:   'https://api.kitwallet.app',
+      fastnearUrl:     'https://api.fastnear.com/v0',
       accountIdSuffix: 'near',
       mpcPublicKey:    new PublicKey({
         keyType: KeyType.ED25519,

--- a/packages/near-fast-auth-signer/src/utils/types.ts
+++ b/packages/near-fast-auth-signer/src/utils/types.ts
@@ -19,7 +19,8 @@ type ProductionNetwork = {
   sentryDsn?: string;
   fastAuth: {
     mpcRecoveryUrl: string;
-    authHelperUrl: string; // TODO refactor: review by fastauth team
+    authHelperUrl: string;
+    fastnearUrl?: string;
     accountIdSuffix: string;
     mpcPublicKey: PublicKey,
     firebase: {


### PR DESCRIPTION
This PR contains implementation for introducing fastnear on mainnet only.

[As per issue](https://github.com/fastnear/fastnear-api-server-rs/issues/2), unfortunately it is currently supporting mainnet environment only. 

Currently some of accounts on near.org fail to login due to issue on kitwallet. This PR will resolve authentication issues on mainnet/near.org.

I have tested following on Chrome browser:
Mainnet:
1. Authenticate with existing account (success)
2. Create new account (success)
3. Authenticate with account created above (success)

Testnet:
Same flow, however confirmed that logic implemented on PR is not executed as per design.

