### PR TITLE
Initial implementation of queryAPI on fetchAccountIds

### DIFF
--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -29,7 +29,7 @@ const fetchAccountIdFromQueryApi = async (publicKey: string): Promise<string | n
         operationName: 'AccountIdByPublicKey',
       }),
     });
-    if (res) {
+    if (res.ok) {
       const response = await res.json();
       if (response.data) {
         const data = response.data.dataplatform_near_access_keys_v1_access_keys_v1[0];

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -40,6 +40,7 @@ const fetchAccountIdFromQueryApi = async (publicKey: string): Promise<string | n
     // Not tracking error here because it is possible that the public key is not on chain
     console.log(`Fail to retrieve account id with public key ${publicKey} from queryAPI: ${e}`);
   }
+  return null;
 };
 
 /**

--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -2,10 +2,45 @@ import { captureException } from '@sentry/react';
 import { KeyPair } from 'near-api-js';
 
 import { withTimeout } from '../utils';
-import { network } from '../utils/config';
+import { network, networkId } from '../utils/config';
 import {
   CLAIM, getUserCredentialsFrpSignature
 } from '../utils/mpc-service';
+
+const fetchAccountIdFromQueryApi = async (publicKey: string): Promise<string | null> => {
+  const query = `query AccountIdByPublicKey {
+    dataplatform_near_access_keys_v1_access_keys_v1(
+      where: {public_key: {_eq: "${publicKey}"}, deleted_by_receipt_id: {_is_null: true}, account_deleted_by_receipt_id: {_is_null: true}}
+    ) {
+      account_id
+      public_key
+      created_by_receipt_id
+      last_updated_block_height
+    }
+  }`;
+
+  try {
+    const res = await fetch(network.fastAuth.queryApiUrl, {
+      method:  'POST',
+      headers: { 'x-hasura-role': 'dataplatform_near' },
+      body:    JSON.stringify({
+        query,
+        variables:     {},
+        operationName: 'AccountIdByPublicKey',
+      }),
+    });
+    if (res) {
+      const response = await res.json();
+      if (response.data) {
+        const data = response.data.dataplatform_near_access_keys_v1_access_keys_v1[0];
+        return data?.account_id;
+      }
+    }
+  } catch (e) {
+    // Not tracking error here because it is possible that the public key is not on chain
+    console.log(`Fail to retrieve account id with public key ${publicKey} from queryAPI: ${e}`);
+  }
+};
 
 /**
  * Fetches the account IDs associated with a given public key.
@@ -24,6 +59,15 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
       }
     }
 
+    // Currently fast near only support mainnet, once it supports testnet, we need to update this condition
+    if (networkId === 'mainnet') {
+      const accountId = await fetchAccountIdFromQueryApi(publicKey);
+      console.log('accountId', accountId);
+      if (accountId) {
+        return [accountId];
+      }
+    }
+
     try {
       const res = await withTimeout(fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`), KIT_WALLET_WAIT_DURATION);
       if (res) {
@@ -32,7 +76,7 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
       }
       return [];
     } catch (error) {
-      console.log('fetchAccountIds', error);
+      console.log('Unable to fetch account ids:', error);
       captureException(error);
       return [];
     }

--- a/packages/near-fast-auth-signer/src/utils/config.ts
+++ b/packages/near-fast-auth-signer/src/utils/config.ts
@@ -16,6 +16,7 @@ export const networks: Record<NetworkId, Network> = {
     fastAuth:      {
       mpcRecoveryUrl:  'https://near-mpc-recovery-mainnet.api.pagoda.co',
       authHelperUrl:   'https://api.kitwallet.app',
+      queryApiUrl:     'https://near-queryapi.api.pagoda.co/v1/graphql',
       accountIdSuffix: 'near',
       mpcPublicKey:    new PublicKey({
         keyType: KeyType.ED25519,

--- a/packages/near-fast-auth-signer/src/utils/types.ts
+++ b/packages/near-fast-auth-signer/src/utils/types.ts
@@ -19,7 +19,8 @@ type ProductionNetwork = {
   sentryDsn?: string;
   fastAuth: {
     mpcRecoveryUrl: string;
-    authHelperUrl: string; // TODO refactor: review by fastauth team
+    authHelperUrl: string;
+    queryApiUrl?: string;
     accountIdSuffix: string;
     mpcPublicKey: PublicKey,
     firebase: {


### PR DESCRIPTION
This PR contains implementation for introducing queryAPI on mainnet only.

[Demo on retrieving account id](https://near.org/dataplatform.near/widget/QueryApi.App?selectedIndexerPath=dataplatform.near/access_keys_v1) 
Click on “Show GraphiQL Code Exporter” icon to get the JS code snippet.

Currently some of accounts on near.org fail to login due to issue on kitwallet. This PR will resolve authentication issues on mainnet/near.org.

I have tested following on Chrome browser:
Mainnet:
1. Authenticate with existing account (success)
2. Create new account (success)
3. Authenticate with account created above (success)

Testnet:
Same flow, however confirmed that logic implemented on PR is not executed as per design.

