### PR TITLE
Sentry improvements

### DIFF
--- a/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
+++ b/packages/near-fast-auth-signer/src/hooks/useAuthState.ts
@@ -26,7 +26,7 @@ export const getAuthState = async (): Promise<AuthState> => {
         keypairs[1],
       );
 
-      if (!accountInfo.accId) {
+      if (!accountInfo?.accId) {
         return false;
       }
 

--- a/packages/near-fast-auth-signer/src/index.tsx
+++ b/packages/near-fast-auth-signer/src/index.tsx
@@ -42,7 +42,16 @@ if (network.sentryDsn) {
     tracesSampleRate:         0.1, // Capture 10% of transactions
 
     // Reconstructing the URL to exclude sensitive query parameters
-    beforeSend(event) {
+    beforeSend(event, hint) {
+      // Check if the error comes from a Chrome extension
+      if (hint && hint.originalException) {
+        const exception = hint.originalException;
+        // @ts-ignore exception has unknown type
+        if (typeof exception?.stack === 'string' && exception?.stack.includes('chrome-extension://')) {
+          // Return null to ignore the event
+          return null;
+        }
+      }
       if (event.request && event.request.url) {
         const url = new URL(event.request.url);
         const queryParams = url.searchParams;


### PR DESCRIPTION
This PR contains two fixes:

1. Another small improvement to filter out unwanted errors coming from Chrome extension.
(In our sentry log, we have too many errors coming from Chrome extensions which are not relevant for tracking errors from fast-auth)

2. Minor syntax error. (With current change, it is possible that `accountInfo` can be returned as null. But existing syntax is applying  `.accId` which it creates an error on sentry