### PR TITLE
Handle AuthCallback errors

### DIFF
--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
+import AuthCallbackError from './AuthCallbackError';
 import { createNEARAccount, fetchAccountIds } from '../../api';
 import { setAccountIdToController } from '../../lib/controller';
 import FirestoreController from '../../lib/firestoreController';
@@ -13,7 +14,9 @@ import {
   decodeIfTruthy, inIframe, isUrlNotJavascriptProtocol, redirectWithError
 } from '../../utils';
 import { basePath, networkId } from '../../utils/config';
-import { checkFirestoreReady, firebaseAuth } from '../../utils/firebase';
+import {
+  checkFirestoreReady, firebaseAuth,
+} from '../../utils/firebase';
 import {
   getAddKeyAction, getAddLAKAction
 } from '../../utils/mpc-service';
@@ -174,6 +177,7 @@ export const onSignIn = async ({
 function AuthCallbackPage() {
   const navigate = useNavigate();
   const [statusMessage, setStatusMessage] = useState('Loading...');
+  const [callbackError, setCallbackError] = useState<Error | null>(null);
 
   const [searchParams] = useSearchParams();
 
@@ -257,8 +261,8 @@ function AuthCallbackPage() {
           });
         } catch (e) {
           captureException(e);
-          console.log('error:', e);
-          redirectWithError({ success_url, failure_url, error: e });
+          setCallbackError(e);
+          // redirectWithError({ success_url, failure_url, error: e });
         }
       } else {
         navigate('/signup');
@@ -267,6 +271,8 @@ function AuthCallbackPage() {
 
     signInProcess();
   }, [navigate, searchParams]);
+
+  if (callbackError) return <AuthCallbackError error={callbackError} failureUrl={decodeIfTruthy(searchParams.get('failure_url'))} />;
 
   return <StyledStatusMessage data-test-id="callback-status-message">{statusMessage}</StyledStatusMessage>;
 }

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -11,7 +11,7 @@ import { createNEARAccount, fetchAccountIds } from '../../api';
 import { setAccountIdToController } from '../../lib/controller';
 import FirestoreController from '../../lib/firestoreController';
 import {
-  decodeIfTruthy, inIframe, isUrlNotJavascriptProtocol, redirectWithError
+  decodeIfTruthy, inIframe, isUrlNotJavascriptProtocol
 } from '../../utils';
 import { basePath, networkId } from '../../utils/config';
 import {
@@ -188,7 +188,6 @@ function AuthCallbackPage() {
         const accountId = decodeIfTruthy(searchParams.get('accountId'));
         const isRecovery = decodeIfTruthy(searchParams.get('isRecovery'));
         const success_url = decodeIfTruthy(searchParams.get('success_url'));
-        const failure_url = decodeIfTruthy(searchParams.get('failure_url'));
         const public_key_lak = decodeIfTruthy(searchParams.get('public_key_lak'));
         const contract_id = decodeIfTruthy(searchParams.get('contract_id'));
         const methodNames = decodeIfTruthy(searchParams.get('methodNames'));
@@ -197,14 +196,9 @@ function AuthCallbackPage() {
         const email = window.localStorage.getItem('emailForSignIn');
 
         if (!email) {
-          const parsedUrl = new URL(
-            failure_url && isUrlNotJavascriptProtocol(failure_url)
-              ? failure_url
-              : window.location.origin + (basePath ? `/${basePath}` : '')
-          );
-          parsedUrl.searchParams.set('code', '500');
-          parsedUrl.searchParams.set('reason', 'Please use the same device and browser to verify your email');
-          window.location.replace(parsedUrl.href);
+          const error = new Error('Please use the same device and browser to verify your email');
+          setCallbackError(error);
+          return;
         }
 
         if (!window.firestoreController) {
@@ -272,7 +266,7 @@ function AuthCallbackPage() {
     signInProcess();
   }, [navigate, searchParams]);
 
-  if (callbackError) return <AuthCallbackError error={callbackError} failureUrl={decodeIfTruthy(searchParams.get('failure_url'))} />;
+  if (callbackError) return <AuthCallbackError error={callbackError} redirectUrl={decodeIfTruthy(searchParams.get('failure_url'))} />;
 
   return <StyledStatusMessage data-test-id="callback-status-message">{statusMessage}</StyledStatusMessage>;
 }

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallback.tsx
@@ -256,7 +256,6 @@ function AuthCallbackPage() {
         } catch (e) {
           captureException(e);
           setCallbackError(e);
-          // redirectWithError({ success_url, failure_url, error: e });
         }
       } else {
         navigate('/signup');

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallbackError.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallbackError.tsx
@@ -1,15 +1,22 @@
-import React from 'react';
+import { sendSignInLinkToEmail } from 'firebase/auth';
+import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Button } from '../../lib/Button';
-import { getFirebaseErrorMessage, isFirebaseError } from '../../utils/firebase';
+import { openToast } from '../../lib/Toast';
+import { extractQueryParams, isUrlNotJavascriptProtocol } from '../../utils';
+import { basePath } from '../../utils/config';
+import {
+  getFirebaseErrorMessage, isFirebaseError, firebaseAuth,
+} from '../../utils/firebase';
 
 const Wrapper = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100%;
 `;
 
 const InnerWrapper = styled.div`
@@ -25,49 +32,74 @@ const ErrorMessage = styled.div`
   margin-bottom: 20px;
 `;
 
-const CTALink = styled.button`
-  padding: 10px 20px;
-  border: none;
-  background-color: #007bff;
-  color: #fff;
-  cursor: pointer;
-  font-size: 15px;
-  border-radius: 5px;
-`;
-
 type AuthCallbackErrorProps = {
-	error: any;
-	failureUrl?: string;
-	onCTAClick?: () => void;
+  error: any;
+  redirectUrl?: string;
 };
 
-function AuthCallbackError(props: AuthCallbackErrorProps) {
-  const {
-    error, onCTAClick
-  } = props;
+function AuthCallbackError({
+  error,
+  redirectUrl,
+}: AuthCallbackErrorProps) {
+  const [searchParams] = useSearchParams();
+  const [inFlight, setInFlight] = useState(false);
+
+  const onClickRedirect = () => {
+    const toUrl = new URL(
+      redirectUrl && isUrlNotJavascriptProtocol(redirectUrl)
+        ? redirectUrl
+        : window.location.origin + (basePath ? `/${basePath}` : '')
+    );
+    window.location.replace(toUrl.href);
+  };
+
+  const resendEmail = async () => {
+    setInFlight(true);
+    const email = window.localStorage.getItem('emailForSignIn');
+    const queryParams = extractQueryParams(searchParams, ['accountId', 'isRecovery', 'success_url', 'failure_url', 'public_key_lak', 'contract_id', 'methodNames']);
+    const newSearchParams = new URLSearchParams(queryParams);
+    try {
+      await sendSignInLinkToEmail(firebaseAuth, email as string, {
+        url:             `${window.location.origin}${basePath ? `/${basePath}` : ''}/auth-callback?${newSearchParams.toString()}`,
+        handleCodeInApp: true,
+      });
+    } catch (e: any) {
+      console.log(e);
+
+      openToast({
+        type:  'ERROR',
+        title: error?.message ?? 'Something went wrong',
+      });
+    } finally {
+      setInFlight(false);
+    }
+  };
 
   const renderContent = () => {
-    if (isFirebaseError(error) && error.code === 'auth/invalid-action-code') {
-      // Firebase error: require resending an email
+    if (isFirebaseError(error)) {
+      const errorMessage = getFirebaseErrorMessage(error);
+
       return (
         <>
-          <ErrorMessage>{getFirebaseErrorMessage(error)}</ErrorMessage>
-          <Button onClick={onCTAClick}>
-            Resend Email Verification
-          </Button>
-          <CTALink disabled>
-            Click here to go home
-          </CTALink>
+          <ErrorMessage>{errorMessage}</ErrorMessage>
+          {error.code === 'auth/invalid-action-code' ? (
+            <Button size="large" onClick={resendEmail} disabled={inFlight} label={inFlight ? 'Sending Email Verification...' : 'Resend Email Verification'} />
+          ) : (
+            <Button size="large" onClick={onClickRedirect}>
+              Click here to go home
+            </Button>
+          )}
         </>
       );
     }
     // Other error
+    const errorMessage = error.message ?? 'An unexpected error occurred';
     return (
       <>
-        <ErrorMessage>An unexpected error occurred</ErrorMessage>
-        <CTALink disabled>
+        <ErrorMessage>{errorMessage}</ErrorMessage>
+        <Button onClick={onClickRedirect}>
           Click here to go home
-        </CTALink>
+        </Button>
       </>
     );
   };

--- a/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallbackError.tsx
+++ b/packages/near-fast-auth-signer/src/components/AuthCallback/AuthCallbackError.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Button } from '../../lib/Button';
+import { getFirebaseErrorMessage, isFirebaseError } from '../../utils/firebase';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    width: 100%;
+`;
+
+const InnerWrapper = styled.div`
+  width: 25%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ErrorMessage = styled.div`
+  text-align: center;
+  margin-bottom: 20px;
+`;
+
+const CTALink = styled.button`
+  padding: 10px 20px;
+  border: none;
+  background-color: #007bff;
+  color: #fff;
+  cursor: pointer;
+  font-size: 15px;
+  border-radius: 5px;
+`;
+
+type AuthCallbackErrorProps = {
+	error: any;
+	failureUrl?: string;
+	onCTAClick?: () => void;
+};
+
+function AuthCallbackError(props: AuthCallbackErrorProps) {
+  const {
+    error, onCTAClick
+  } = props;
+
+  const renderContent = () => {
+    if (isFirebaseError(error) && error.code === 'auth/invalid-action-code') {
+      // Firebase error: require resending an email
+      return (
+        <>
+          <ErrorMessage>{getFirebaseErrorMessage(error)}</ErrorMessage>
+          <Button onClick={onCTAClick}>
+            Resend Email Verification
+          </Button>
+          <CTALink disabled>
+            Click here to go home
+          </CTALink>
+        </>
+      );
+    }
+    // Other error
+    return (
+      <>
+        <ErrorMessage>An unexpected error occurred</ErrorMessage>
+        <CTALink disabled>
+          Click here to go home
+        </CTALink>
+      </>
+    );
+  };
+
+  return (
+    <Wrapper>
+      <InnerWrapper>
+        {renderContent()}
+      </InnerWrapper>
+    </Wrapper>
+  );
+}
+
+export default AuthCallbackError;

--- a/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
+++ b/packages/near-fast-auth-signer/src/components/VerifyEmail/verify-email.tsx
@@ -75,25 +75,13 @@ function VerifyEmailPage() {
         handleCodeInApp: true,
       });
       window.localStorage.setItem('emailForSignIn', email);
-
-      openToast({
-        type:  'SUCCESS',
-        title: 'Email resent successfully!',
-      });
     } catch (error: any) {
       console.log(error);
       redirectWithError({ success_url, failure_url, error });
 
-      if (typeof error?.message === 'string') {
-        openToast({
-          type:  'ERROR',
-          title: error.message,
-        });
-        return;
-      }
       openToast({
         type:  'ERROR',
-        title: 'Something went wrong',
+        title: error?.message ?? 'Something went wrong',
       });
     } finally {
       setInFlight(false);

--- a/packages/near-fast-auth-signer/src/utils/firebase.ts
+++ b/packages/near-fast-auth-signer/src/utils/firebase.ts
@@ -1,8 +1,13 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { initializeApp } from 'firebase/app';
+import { initializeApp, FirebaseError } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 
 import { network } from './config';
+
+const errorCodeMessageMap = {
+  'auth/invalid-action-code': 'This link is malformed, expired or has already been used. Please request a new one.',
+  // Add more error code-message mappings as needed
+};
 
 // Initialize Firebase
 export const firebaseApp = initializeApp(network.fastAuth.firebase);
@@ -15,3 +20,11 @@ export const checkFirestoreReady = async () => firebaseAuth.authStateReady()
     }
     return false;
   });
+
+export const isFirebaseError = (error: Error) => error instanceof FirebaseError;
+
+export const getFirebaseErrorMessage = (error: FirebaseError) => {
+  const errorCode = error.code;
+
+  return errorCodeMessageMap[errorCode] || 'An unknown error occurred. Please try again later.';
+};

--- a/packages/near-fast-auth-signer/src/utils/index.ts
+++ b/packages/near-fast-auth-signer/src/utils/index.ts
@@ -89,3 +89,14 @@ export const withTimeout = async (promise, timeoutMs) => {
 
 export const isSafari = () => /^((?!chrome|android).)*safari/i
   .test(navigator.userAgent);
+
+export const extractQueryParams = (searchParams: URLSearchParams, paramNames: string[]) => {
+  const params = {};
+  paramNames.forEach((paramName) => {
+    const paramValue = searchParams.get(paramName);
+    if (paramValue !== null) {
+      params[paramName] = paramValue;
+    }
+  });
+  return params;
+};


### PR DESCRIPTION
This PR handles a common error in `fast-auth` testing which is the firebase `auth/invalid-action-code` error, and also adds a generic error handling to the page. We should be able to show errors in the `AuthCallback` page instead of just redirecting users to the gateway url where they don't have much info on what happened.

To see this simple view  you can trigger any error, e.g clicking an already used firebase link from an email.

Example below

![iPhone-13-PRO-localhost](https://github.com/near/fast-auth-signer/assets/5072922/bb1e7bad-14f3-4751-a543-638ea5d72eb2)

