### PR TITLE
Add transactionHash to multiChain response post message

### DIFF
--- a/packages/near-fast-auth-signer/src/components/SignMultichain/SignMultichain.tsx
+++ b/packages/near-fast-auth-signer/src/components/SignMultichain/SignMultichain.tsx
@@ -128,7 +128,9 @@ function SignMultichain() {
           feeProperties,
         });
         if (response.success && 'transactionHash' in response) {
-          window.parent.postMessage({ type: 'multiChainResponse', message: `Successfully sign and send transaction, ${response.transactionHash}`, closeIframe: true }, '*');
+          window.parent.postMessage({
+            type: 'multiChainResponse', transactionHash: response.transactionHash, message: 'Successfully signed and sent transaction', closeIframe: true
+          }, '*');
         } else if (response.success === false) {
           onError(response.errorMessage);
         }

--- a/packages/near-fast-auth-signer/src/components/SignMultichain/utils.ts
+++ b/packages/near-fast-auth-signer/src/components/SignMultichain/utils.ts
@@ -167,7 +167,7 @@ export const multichainAssetToNetworkName = (chainDetails: ChainDetails) => {
     return {
       1:        'Ethereum Mainnet',
       56:       'Binance Smart Chain Mainnet',
-      97:       'Binace Smart Chain Testnet',
+      97:       'Binance Smart Chain Testnet',
       11155111: 'Ethereum Sepolia Network'
     }[Number(chainDetails.chainId)];
   }


### PR DESCRIPTION
Include `transactionHash` as part of `postMessage` to parent to signal a successful transaction.