### PR TITLE
Bring back query api

### DIFF
--- a/packages/near-fast-auth-signer/src/api/index.ts
+++ b/packages/near-fast-auth-signer/src/api/index.ts
@@ -3,10 +3,46 @@ import { KeyPair } from 'near-api-js';
 
 import { LimitedAccessKey, NewAccountResponse } from './types';
 import { withTimeout } from '../utils';
-import { network } from '../utils/config';
+import { network, networkId } from '../utils/config';
 import {
   CLAIM, getUserCredentialsFrpSignature
 } from '../utils/mpc-service';
+
+const fetchAccountIdFromQueryApi = async (publicKey: string): Promise<string | null> => {
+  const query = `query AccountIdByPublicKey {
+    dataplatform_near_access_keys_v1_access_keys_v1(
+      where: {public_key: {_eq: "${publicKey}"}, deleted_by_receipt_id: {_is_null: true}, account_deleted_by_receipt_id: {_is_null: true}}
+    ) {
+      account_id
+      public_key
+      created_by_receipt_id
+      last_updated_block_height
+    }
+  }`;
+
+  try {
+    const res = await fetch(network.fastAuth.queryApiUrl, {
+      method:  'POST',
+      headers: { 'x-hasura-role': 'dataplatform_near' },
+      body:    JSON.stringify({
+        query,
+        variables:     {},
+        operationName: 'AccountIdByPublicKey',
+      }),
+    });
+    if (res.ok) {
+      const response = await res.json();
+      if (response.data) {
+        const data = response.data.dataplatform_near_access_keys_v1_access_keys_v1[0];
+        return data?.account_id;
+      }
+    }
+  } catch (e) {
+    // Not tracking error here because it is possible that the public key is not on chain
+    console.log(`Fail to retrieve account id with public key ${publicKey} from queryAPI: ${e}`);
+  }
+  return null;
+};
 
 /**
  * Fetches the account IDs associated with a given public key.
@@ -25,6 +61,15 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
       }
     }
 
+    // Currently fast near only support mainnet, once it supports testnet, we need to update this condition
+    if (networkId === 'mainnet') {
+      const accountId = await fetchAccountIdFromQueryApi(publicKey);
+      console.log('accountId', accountId);
+      if (accountId) {
+        return [accountId];
+      }
+    }
+
     try {
       const res = await withTimeout(fetch(`${network.fastAuth.authHelperUrl}/publicKey/${publicKey}/accounts`), KIT_WALLET_WAIT_DURATION);
       if (res) {
@@ -33,7 +78,7 @@ export const fetchAccountIds = async (publicKey: string): Promise<string[]> => {
       }
       return [];
     } catch (error) {
-      console.log('fetchAccountIds', error);
+      console.log('Unable to fetch account ids:', error);
       captureException(error);
       return [];
     }

--- a/packages/near-fast-auth-signer/src/utils/config.ts
+++ b/packages/near-fast-auth-signer/src/utils/config.ts
@@ -16,6 +16,7 @@ export const networks: Record<NetworkId, Network> = {
     fastAuth:      {
       mpcRecoveryUrl:  'https://near-mpc-recovery-mainnet.api.pagoda.co',
       authHelperUrl:   'https://api.kitwallet.app',
+      queryApiUrl:     'https://near-queryapi.api.pagoda.co/v1/graphql',
       accountIdSuffix: 'near',
       mpcPublicKey:    new PublicKey({
         keyType: KeyType.ED25519,

--- a/packages/near-fast-auth-signer/src/utils/types.ts
+++ b/packages/near-fast-auth-signer/src/utils/types.ts
@@ -19,7 +19,8 @@ type ProductionNetwork = {
   sentryDsn?: string;
   fastAuth: {
     mpcRecoveryUrl: string;
-    authHelperUrl: string; // TODO refactor: review by fastauth team
+    authHelperUrl: string;
+    queryApiUrl?: string;
     accountIdSuffix: string;
     mpcPublicKey: PublicKey,
     firebase: {


### PR DESCRIPTION
In the past, commit related to query API implementation has been removed by accident. 

It was removed on [this PR](https://github.com/near/fast-auth-signer/pull/215) but I have confirmed with @Pessina that it was removed by accident. (Double checked just to be sure)