### PR TITLE
Persist query param upon login redirect

### DIFF
--- a/packages/near-fast-auth-signer/src/components/CreateAccount/CreateAccount.tsx
+++ b/packages/near-fast-auth-signer/src/components/CreateAccount/CreateAccount.tsx
@@ -249,6 +249,11 @@ function CreateAccount() {
     recordEvent('click-has-account-sign-in');
   };
 
+  const loginQueryParam = useCallback(() => {
+    searchParams.set('isRecovery', 'true');
+    return searchParams.toString();
+  }, [searchParams]);
+
   return (
     <StyledContainer inIframe={inIframe()}>
       <CreateAccountForm ref={createAccountFormRef} inIframe={inIframe()} onSubmit={handleSubmit(createAccount)}>
@@ -257,7 +262,7 @@ function CreateAccount() {
           <p className="desc">
             <span>Have an account?</span>
             {' '}
-            <Link to="/login" data-test-id="create_login_link" onClick={handleSignInClick}>Sign in</Link>
+            <Link to={{ pathname: '/login', search: loginQueryParam() }} data-test-id="create_login_link" onClick={handleSignInClick}>Sign in</Link>
           </p>
         </header>
         <Input


### PR DESCRIPTION
This PR contains fix for the bug where on login page, if `sign-in` redirect button is clicked, it lost query param context. 

![Greenshot 2024-06-24 17 40 58](https://github.com/near/fast-auth-signer/assets/6027014/ce0493ca-456b-478e-9cdc-f148aa2dd9da)
<img width="917" alt="Greenshot 2024-06-24 17 41 06" src="https://github.com/near/fast-auth-signer/assets/6027014/7784a0ab-928d-4a26-a22d-ad9a2ea9ab5b">

Bug is fixed by manually passing the query param on `Link` component. 