### PR TITLE
Fix/multichain test browser rendering

### DIFF
--- a/packages/near-fast-auth-signer-e2e-tests/tests/models/SignMultiChain.ts
+++ b/packages/near-fast-auth-signer-e2e-tests/tests/models/SignMultiChain.ts
@@ -22,8 +22,11 @@ type TransactionDetail = {
 class SignMultiChain {
   private readonly page: Page;
 
+  private isWebkit: boolean;
+
   constructor(page: Page) {
     this.page = page;
+    this.isWebkit = false;
   }
 
   // Wait for about 4 minutes to get multichain response
@@ -47,13 +50,18 @@ class SignMultiChain {
     await this.page.check(`input#${assetType.toLowerCase()}`);
     await this.page.fill('input#amount', `${amount}`);
     await this.page.fill('input#address', `${address}`);
-    await this.page.click('button[type="submit"]');
+    // Webkit browsers only trigger submit if button is double-clicked, this is only happening with our test dapp
+    if (this.isWebkit) {
+      await this.page.dblclick('button[type="submit"]');
+    } else {
+      await this.page.click('button[type="submit"]');
+    }
   }
 
   async clickApproveButton() {
     const frame = getFastAuthIframe(this.page);
     const approveButton = frame.locator('button:has-text("Approve")');
-    await approveButton.waitFor({ state: 'visible' });
+    await approveButton.waitFor();
     await approveButton.click();
   }
 
@@ -69,6 +77,10 @@ class SignMultiChain {
   // Disable pointer events on overlay elements within the iframe and page
   async disablePointerEventsInterruption() {
     await this.page.addStyleTag({ content: 'iframe#webpack-dev-server-client-overlay { pointer-events: none; z-index: -1; }' });
+  }
+
+  setIsWebkit(isWebkit: boolean) {
+    this.isWebkit = isWebkit;
   }
 }
 

--- a/packages/near-fast-auth-signer-e2e-tests/tests/signMultiChain/sign-multi-chain.spec.ts
+++ b/packages/near-fast-auth-signer-e2e-tests/tests/signMultiChain/sign-multi-chain.spec.ts
@@ -2,10 +2,10 @@ import { KeyPair } from '@near-js/crypto';
 import { expect, Page, test } from '@playwright/test';
 
 import {
-  receivingAddresses, getFastAuthIframe
+  receivingAddresses,
 } from '../../utils/constants';
 import { overridePasskeyFunctions } from '../../utils/passkeys';
-import { isWalletSelectorLoaded } from '../../utils/walletSelector';
+import { isWalletSelectorLoaded, ensureIframeIsVisible, getIframeElement } from '../../utils/walletSelector';
 import SignMultiChain from '../models/SignMultiChain';
 
 let page: Page;
@@ -15,6 +15,8 @@ const userFAK = process.env.MULTICHAIN_TEST_ACCOUNT_FAK;
 const accountId = process.env.MULTICHAIN_TEST_ACCOUNT_ID;
 
 const fakKeyPair = KeyPair.fromString(userFAK);
+
+let isWebkit = false;
 
 const isAuthenticated = async (loggedIn: boolean) => {
   if (!page) return;
@@ -33,9 +35,11 @@ const isAuthenticated = async (loggedIn: boolean) => {
 
 test.describe('Sign MultiChain', () => {
   test.beforeAll(async ({ browser }) => {
+    isWebkit = browser.browserType().name() === 'webkit';
     const context = await browser.newContext();
     page = await context.newPage();
     signMultiChain = new SignMultiChain(page);
+    signMultiChain.setIsWebkit(isWebkit);
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
 
@@ -61,13 +65,14 @@ test.describe('Sign MultiChain', () => {
     await signMultiChain.submitTransaction({
       keyType: 'unknownKey', assetType: 'bnb', amount: 0.01, address: receivingAddresses.ETH_BNB
     });
-    const frame = getFastAuthIframe(page);
-    await frame.locator('text=Send 0.01 BNB').waitFor({ state: 'visible' });
-    await frame.locator('button:has-text("Approve")').waitFor({ state: 'visible' });
-    await expect(frame.getByText('We don’t recognize this app, proceed with caution')).toBeVisible();
-    await expect(frame.locator('button:has-text("Approve")')).toBeDisabled();
-    await frame.locator('input[type="checkbox"]').check();
-    await expect(frame.locator('button:has-text("Approve")')).toBeEnabled();
+    await ensureIframeIsVisible(page);
+    const iframe =  await getIframeElement(page);
+    await expect(iframe.getByText('Send 0.01 BNB')).toBeVisible();
+    await expect(iframe.getByText('We don’t recognize this app, proceed with caution')).toBeVisible();
+    await iframe.locator('button:has-text("Approve")').waitFor({ state: 'visible' });
+    await expect(iframe.locator('button:has-text("Approve")')).toBeDisabled();
+    await iframe.locator('input[type="checkbox"]').check();
+    await expect(iframe.locator('button:has-text("Approve")')).toBeEnabled();
   });
 
   test('Should Fail: if not authenticated', async () => {
@@ -76,9 +81,10 @@ test.describe('Sign MultiChain', () => {
     await signMultiChain.submitAndApproveTransaction({
       keyType: 'personalKey', assetType: 'eth', amount: 0.001, address: receivingAddresses.ETH_BNB
     });
+    await ensureIframeIsVisible(page);
+    const iframe =  await getIframeElement(page);
     await signMultiChain.waitForMultiChainResponse();
-    await expect(page.locator('#nfw-connect-iframe')).toBeVisible();
-    await expect(getFastAuthIframe(page).getByText('You are not authenticated or there has been an indexer failure')).toBeVisible();
+    await expect(iframe.getByText('You are not authenticated or there has been an indexer failure')).toBeVisible();
   });
 
   test('Should Pass: Send ETH with Personal Key', async () => {
@@ -87,8 +93,9 @@ test.describe('Sign MultiChain', () => {
     await signMultiChain.submitTransaction({
       keyType: 'personalKey', assetType: 'eth', amount: 0.001, address: receivingAddresses.ETH_BNB
     });
-    const frame = getFastAuthIframe(page);
-    await frame.locator('text=Send 0.001 ETH').waitFor({ state: 'visible' });
+    await ensureIframeIsVisible(page);
+    const iframe =  await getIframeElement(page);
+    await expect(iframe.getByText('Send 0.001 ETH')).toBeVisible();
     await signMultiChain.clickApproveButton();
     const multiChainResponse = await signMultiChain.waitForMultiChainResponse();
     expect(multiChainResponse.transactionHash).toBeDefined();

--- a/packages/near-fast-auth-signer-e2e-tests/utils/walletSelector.ts
+++ b/packages/near-fast-auth-signer-e2e-tests/utils/walletSelector.ts
@@ -4,3 +4,15 @@ export const isWalletSelectorLoaded = async (page: Page) => {
   const walletSelector = page.getByTestId('app-container');
   await expect(walletSelector).toBeVisible();
 };
+
+export const ensureIframeIsVisible = async (page: Page) => {
+  await page.waitForSelector('#nfw-connect-iframe');
+  await expect(page.locator('#nfw-connect-iframe')).toBeVisible();
+};
+
+export const getIframeElement = async (page: Page) => {
+  const iframeElementHandle = await page.$('#nfw-connect-iframe');
+  const iframe = await iframeElementHandle.contentFrame();
+  await iframe.waitForLoadState('domcontentloaded');
+  return iframe;
+};


### PR DESCRIPTION
The submit button on [this line](https://github.com/near/fast-auth-signer/blob/6eea2b57b3c3087a8ddb7dd965a6198adf066dc7/packages/near-fast-auth-signer-e2e-tests/tests/models/SignMultiChain.ts#L50) does not work on first click in webkit browsers, so the transaction does not even submit for the test to run. Until it double clicks.
The quick fix now is to double click the submit button if the browser is webkit, else traditional click.